### PR TITLE
Three fixes in the command line interface

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -60,6 +60,7 @@ def main(sys_args=None):
                              "(default='critical')")
     parser.add_argument('--obsid',
                         action='append',
+                        type=float,
                         help="Process only this obsid (can specify multiple times, default=all")
     parser.add_argument('--quiet',
                         action='store_true',
@@ -127,7 +128,9 @@ def run_aca_review(load_name=None, *, acas=None, make_html=True, outdir=None,
         if outdir is None:
             if not load_name:
                 raise ValueError('load_name must be provided if outdir is not specified')
-            outdir = re.sub(r'(_proseco)?.pkl', '', load_name) + '_aca_preview'
+            # Chop any directory path from load_name
+            load_name = Path(load_name).name
+            outdir = re.sub(r'(_proseco)?.pkl', '', load_name) + '_sparkles'
         outdir = Path(outdir)
         outdir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
- Cast --obsid as float
- Chop path prefix from input `load_name` (makes nicer title in HTML)
- As a desired side-effect that makes the auto `outdir` default to
  being in the current directory.  (@jeanconn - you were right, I was wrong.  :smile_cat:)

Fixes #32.