### PR TITLE
Make the sparkles catalog table output more readable.

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -371,6 +371,19 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         if 'maxmag' in self.colnames:
             del self['maxmag']
 
+        # Customizations for ACAReviewTable.  Don't really need 2 decimals on these.
+        for name in ('yang', 'zang', 'row', 'col'):
+            self._default_formats[name] = '.1f'
+
+        # Make mag column have an extra space for catalogs with all mags < 10.0
+        self._default_formats['mag'] = '5.2f'
+
+        if self.colnames[0] != 'idx':
+            # Move 'idx' to first column.  This is really painful currently.
+            self.add_column(Column(self['idx'], name='idx_temp'), index=0)
+            del self['idx']
+            self.rename_column('idx_temp', 'idx')
+
     def run_aca_review(self, *, report_dir=None, report_level='none', roll_level='none'):
         """Do aca review based for this catalog
 


### PR DESCRIPTION
```
idx slot    id    type  sz p_acq  mag  mag_err   yang    zang   row    col   dim res halfw
--- ---- -------- ---- --- ----- ----- ------- ------- ------- ------ ------ --- --- -----
  1    0        2  FID 8x8 0.000  7.00    0.00  -773.2 -1742.0  160.8 -345.4   1   1    25
  2    1        4  FID 8x8 0.000  7.00    0.00  2140.2   166.6 -424.5   39.1   1   1    25
  3    2        5  FID 8x8 0.000  7.00    0.00 -1826.3   160.2  373.0   36.5   1   1    25
  4    3 56229936  BOT 6x6 0.982  6.72    0.04  -428.1  2322.5   93.1  472.3  20   1   160
  5    4 56232832  BOT 6x6 0.978  8.39    0.11 -1417.2  1769.7  291.9  360.5  20   1   160
  6    5 56232928  BOT 6x6 0.981  7.39    0.06   500.1   255.9  -94.0   56.3  20   1   160
  7    6 57938472  BOT 6x6 0.982  6.86    0.04   682.3 -1121.1 -131.2 -219.7  20   1   160
  8    7 57948128  BOT 6x6 0.982  7.16    0.04  1223.2   -14.0 -239.3    2.5  20   1   160
  9    0 57938024  ACQ 6x6 0.976  8.68    0.16  1497.7 -2275.9 -297.0 -453.7  20   1   160
 10    1 57410136  ACQ 6x6 0.976  8.71    0.30 -1504.4 -2033.9  308.4 -405.4  20   1   160
 11    2 56242088  ACQ 6x6 0.976  8.75    0.12 -1685.8  1421.2  345.7  290.2  20   1   160
```

Closes #23 