### PR TITLE
Make roll_options 'aca' element always be ACAReviewTable

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -344,6 +344,7 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         # up to 2 decimal points.  This is the case when obsid is taken from the
         # ORviewer dict of ACATable pickles from prelim review.  Tidy things up
         # in these cases.
+        # TODO: make base obsid MetaAttribute in proseco handle this munging.
         if obsid is not None:
             f_obsid = round(float(obsid), 2)
             i_obsid = int(f_obsid)
@@ -464,11 +465,9 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         # as the first row.
         opts = [opt.copy() for opt in self.roll_options]
         rolls = [Quat(opt['aca'].att).roll for opt in self.roll_options]
-        acas = [ACAReviewTable(opt['aca'], obsid=roll)
-                for opt, roll in zip(opts, rolls)]
+        acas = [opt['aca'] for opt in opts]
 
-        for roll, opt in zip(rolls, opts):
-            opt['roll'] = roll
+        for opt in opts:
             del opt['aca']
 
         opts_table = Table(opts, names=['roll', 'P2', 'n_stars', 'improvement',

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -324,7 +324,10 @@ class RollOptimizeMixin:
         q_att = Quat(self.att)
         q_targ = calc_targ_from_aca(q_att, 0, 0)
 
-        roll_options = [{'aca': deepcopy(self),
+        # Special case, first roll option is self but with obsid set to roll
+        acar = deepcopy(self)  # TODO: should this be self.__class__(self) or self.copy()?
+        acar.obsid = round(q_att.roll, 2)
+        roll_options = [{'aca': acar,
                          'P2': P2,
                          'n_stars': n_stars,
                          'improvement': 0.0,
@@ -351,7 +354,7 @@ class RollOptimizeMixin:
             improvement = improve_metric(n_stars, P2, n_stars_rolled, P2_rolled)
 
             if improvement > 0.3:
-                roll_option = {'aca': aca_rolled,
+                roll_option = {'aca': self.__class__(aca_rolled, obsid=roll),
                                'P2': P2_rolled,
                                'n_stars': n_stars_rolled,
                                'improvement': improvement}

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -52,6 +52,45 @@ def test_review_catalog(tmpdir):
     assert (obspath / 'rolls' / 'index.html').exists()
 
 
+def test_review_roll_options(tmpdir):
+    """
+    Test that the 'aca' key in the roll_option dict is an ACAReviewTable
+    and that the first one has the same messages as the base (original roll)
+    version
+
+    :param tmpdir: temp dir supplied by pytest
+    :return: None
+    """
+    # This is a catalog that has a critical message and one roll option
+    kwargs = {'att': (160.9272490316051, 14.851572261604668, 99.996111473617802),
+              'date': '2019:046:07:16:58.449',
+              'detector': 'ACIS-S',
+              'dither_acq': (7.9992, 7.9992),
+              'dither_guide': (7.9992, 7.9992),
+              'focus_offset': 0.0,
+              'man_angle': 1.792525648258372,
+              'n_acq': 8,
+              'n_fid': 3,
+              'n_guide': 5,
+              'obsid': 21477,
+              'sim_offset': 0.0,
+              't_ccd_acq': -11.14616454993262,
+              't_ccd_guide': -11.150381856818923}
+
+    aca = get_aca_catalog(**kwargs)
+    acar = aca.get_review_table()
+    acar.run_aca_review(report_dir=tmpdir, roll_level='critical')
+
+    assert len(acar.roll_options) == 2
+
+    # First roll_option is at the same attitude (and roll) as original.  The check
+    # code is run again independently but the outcome should be the same.
+    assert acar.roll_options[0]['aca'].messages == acar.messages
+
+    for opt in acar.roll_options:
+        assert isinstance(opt['aca'], ACAReviewTable)
+
+
 def test_probs_weak_reference():
     """
     Test issues related to the weak reference to self.acqs within the AcqProbs


### PR DESCRIPTION
Previously the `'aca'` key element of each roll option dict was either `ACAReviewTable` (for the first one) or `ACATable` for subsequent ones (new roll options).  Then later they were all being converted to `ACAReviewTable` and the original tossed.

This makes them all be `ACAReviewTable` from the outset and be persistent so that the messages generated in review appear on the relevant objects in the `roll_options` list.

Fixes #61 
