### PR TITLE
Update the really bright star checks for proseco 4.4

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -777,7 +777,10 @@ Predicted Acq CCD temperature (init) : {self.acqs.t_ccd:.1f}"""
             self.add_message('warning', f'P2: {P2:.2f} less than {P2_lim + 1} for {obs_type}')
 
     def check_guide_count(self):
-        """Check for sufficient guide star fractional count
+        """
+        Check for sufficient guide star fractional count.
+
+        Also check for multiple very-bright stars
 
         """
         obs_type = 'ER' if self.is_ER else 'OR'
@@ -791,6 +794,12 @@ Predicted Acq CCD temperature (init) : {self.acqs.t_ccd:.1f}"""
             self.add_message(
                 'critical',
                 f'{obs_type} count of guide stars {self.guide_count:.2f} < {count_lim}')
+
+        bright_cnt_lim = 1 if self.is_OR else 3
+        if np.count_nonzero(self['mag'] < 6.1) > bright_cnt_lim:
+            self.add_message(
+                'caution',
+                f'{obs_type} with more than {bright_cnt_lim} stars brighter than 6.1.')
 
     def check_pos_err_guide(self, star):
         """Warn on stars with larger POS_ERR (warning at 1" critical at 2")

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -841,10 +841,7 @@ Predicted Acq CCD temperature (init) : {self.acqs.t_ccd:.1f}"""
     def check_too_bright_guide(self, star):
         """Warn on guide stars that may be too bright.
 
-        - Critical if MAG_ACA_ERR used in selection is less than 0.1
-        - Critical if within 2 * mag_err of the hard 5.8 limit, warn within 3 * mag_err
-        - Warning if brighter than 6.1 (should be double-checked in
-          context of other candidates).
+        - Critical if within 2 * mag_err of the hard 5.8 limit, caution within 3 * mag_err
 
         """
         agasc_id = star['id']
@@ -852,23 +849,13 @@ Predicted Acq CCD temperature (init) : {self.acqs.t_ccd:.1f}"""
         mag_err = star['mag_err']
         mag_aca_err = star['MAG_ACA_ERR'] * 0.01
         for mult, category in ((2, 'critical'),
-                               (3, 'warning')):
+                               (3, 'caution')):
             if star['mag'] - (mult * mag_err) < 5.8:
                 self.add_message(
                     category,
                     f'Guide star {agasc_id} within {mult}*mag_err of 5.8 '
                     f'(mag_err={mag_err:.2f})', idx=idx)
                 break
-        if (star['mag'] < 6.1) and (mag_aca_err < 0.1):
-            self.add_message(
-                'critical',
-                f'Guide star {agasc_id} < 6.1 with small MAG_ACA_ERR={mag_aca_err:.2f}.  '
-                f'Double check selection.',
-                idx=idx)
-        elif star['mag'] < 6.1:
-            self.add_message(
-                'warning',
-                f'Guide star {agasc_id} < 6.1. Double check selection.', idx=idx)
 
     def check_bad_stars(self, entry):
         """Check if entry (guide or acq) is in bad star set from proseco

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -210,20 +210,6 @@ def test_too_bright_guide_magerr():
     assert '2*mag_err of 5.8' in msg['text']
 
 
-def test_too_bright_guide_mag_aca_err():
-    """Test the check for too-bright guide stars with small MAG_ACA_ERR"""
-    stars = StarsTable.empty()
-    # Add two stars because separate P2 tests seem to break with just one star
-    stars.add_fake_star(id=100, yang=100, zang=-200, mag=6.0, mag_err=0.02, MAG_ACA_ERR=0)
-    stars.add_fake_star(id=101, yang=0, zang=500, mag=8.0)
-    aca = get_aca_catalog(**mod_std_info(n_fid=0), stars=stars, dark=DARK40, raise_exc=True)
-    aca = ACAReviewTable(aca)
-    aca.check_too_bright_guide(aca.guides.get_id(100))
-    msg = aca.messages[0]
-    assert msg['category'] == 'critical'
-    assert 'small MAG_ACA_ERR' in msg['text']
-
-
 def test_check_fid_spoiler_score():
     """Test checking fid spoiler score"""
     stars = StarsTable.empty()


### PR DESCRIPTION
Update the really bright star checks for proseco 4.4 .

This changes the "within 3 sigma of 5.8" warning to a caution, removes the "bright star but small MAG_ACA_ERR check" (which doesn't apply now that bright stars have at least 0.1 mag effective error), and adds a new caution statement if an OR has more than 1 star brighter than 6.1 or if an ER has more than 3 stars brighter than 6.1 mag.  Those might get missed by the pure "guide_count" metric, and by the time an observation has multiple really-bright stars, it might be worth a look.