### PR TITLE
Remove the hack of overloading obsid with roll for roll options

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -187,7 +187,6 @@ def run_aca_review(load_name=None, *, acas=None, make_html=True, outdir=None,
 
         # Special case when running a set of roll options for one obsid
         is_roll_report = all(aca.is_roll_option for aca in acas)
-        context['is_roll_report'] = is_roll_report
 
         context['id_label'] = 'Roll' if is_roll_report else 'Obsid'
 

--- a/sparkles/index_template_preview.html
+++ b/sparkles/index_template_preview.html
@@ -63,8 +63,8 @@ proseco version: {{proseco_version}}
 
 {% for aca in acas %}
 
-<a name="id{{aca.obsid}}"></a>
-<h2> {% if aca.roll %}Roll{% else %}Obsid{% endif %} {{aca.obsid}} at {{aca.date}}</h1>
+<a name="id{{aca.report_id}}"></a>
+<h2> {{id_label}} {{aca.report_id}} at {{aca.date}}</h1>
 {% if aca.context['reports_dir'] %}
 <pre>Reports: <a href="{{aca.context['reports_dir']}}/acq/index.html">Acquisition</a> <a href="{{aca.context['reports_dir']}}/guide/index.html">Guide</a></pre>
 {% endif %}

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -325,8 +325,8 @@ class RollOptimizeMixin:
         q_targ = calc_targ_from_aca(q_att, 0, 0)
 
         # Special case, first roll option is self but with obsid set to roll
-        acar = deepcopy(self)  # TODO: should this be self.__class__(self) or self.copy()?
-        acar.obsid = round(q_att.roll, 2)
+        acar = deepcopy(self)
+        acar.is_roll_option = True
         roll_options = [{'aca': acar,
                          'P2': P2,
                          'n_stars': n_stars,
@@ -345,6 +345,7 @@ class RollOptimizeMixin:
             kwargs = self.call_args.copy()
             kwargs['att'] = q_att_roll
 
+            print(kwargs)
             aca_rolled = get_aca_catalog(**kwargs)
 
             P2_rolled = -np.log10(aca_rolled.acqs.calc_p_safe())
@@ -354,7 +355,8 @@ class RollOptimizeMixin:
             improvement = improve_metric(n_stars, P2, n_stars_rolled, P2_rolled)
 
             if improvement > 0.3:
-                roll_option = {'aca': self.__class__(aca_rolled, obsid=roll),
+                roll_option = {'aca': self.__class__(aca_rolled, obsid=self.obsid,
+                                                     is_roll_option=True),
                                'P2': P2_rolled,
                                'n_stars': n_stars_rolled,
                                'improvement': improvement}

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -345,7 +345,6 @@ class RollOptimizeMixin:
             kwargs = self.call_args.copy()
             kwargs['att'] = q_att_roll
 
-            print(kwargs)
             aca_rolled = get_aca_catalog(**kwargs)
 
             P2_rolled = -np.log10(aca_rolled.acqs.calc_p_safe())


### PR DESCRIPTION
This should fix #66 by removing the hack of overloading obsid with roll.

Cc: @jskrist

This requires https://github.com/sot/proseco/pull/281.

Fixes #66.