### PR TITLE
Update text for "not enough 9th mag stars for ER"

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -19,7 +19,8 @@ from matplotlib.patches import Circle
 import numpy as np
 from Quaternion import Quat
 from jinja2 import Template
-from chandra_aca.transform import yagzag_to_pixels, mag_to_count_rate
+from chandra_aca.transform import (yagzag_to_pixels, mag_to_count_rate,
+                                   snr_mag_for_t_ccd)
 from astropy.table import Column, Table
 
 import proseco
@@ -800,9 +801,12 @@ Predicted Acq CCD temperature (init) : {self.acqs.t_ccd:.1f}"""
         """
         obs_type = 'ER' if self.is_ER else 'OR'
         if self.is_ER and self.guide_count_9th < 3.0:
+            # Determine the threshold 9th mag equivalent value at the effective guide t_ccd
+            mag9 = snr_mag_for_t_ccd(self.guides.t_ccd, 9.0, -10.9)
             self.add_message(
                 'critical',
-                f'{obs_type} count of 9th mag guide stars {self.guide_count_9th:.2f} < 3.0')
+                f'{obs_type} count of 9th ({mag9:.1f} for {self.guides.t_ccd:.1f}C) '
+                f'mag guide stars {self.guide_count_9th:.2f} < 3.0')
 
         count_lim = 4.0 if self.is_OR else 6.0
         if self.guide_count < count_lim:

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -53,7 +53,7 @@ def test_guide_count_er():
     assert len(aca.messages) == 1
     msg = aca.messages[0]
     assert msg['category'] == 'critical'
-    assert 'ER count of 9th mag guide stars 0.00 < 3.0' in msg['text']
+    assert 'ER count of 9th' in msg['text']
 
     # This configuration should have not enough stars overall
     stars = StarsTable.empty()

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -30,14 +30,16 @@ def test_review_catalog(tmpdir):
          'idx': 2,
          'text': 'Guide star imposter offset 2.6, limit 2.5 arcsec'},
         {'category': 'critical', 'text': 'P2: 2.84 less than 3.0 for ER'},
-        {'category': 'critical', 'text': 'ER count of 9th mag guide stars 1.57 < 3.0'}]
+        {'category': 'critical', 'text':
+         'ER count of 9th (8.9 for -9.9C) mag guide stars 1.57 < 3.0'}]
 
     assert acar.roll_options is None
 
     msgs = (acar.messages >= 'critical')
     assert msgs == [
         {'category': 'critical', 'text': 'P2: 2.84 less than 3.0 for ER'},
-        {'category': 'critical', 'text': 'ER count of 9th mag guide stars 1.57 < 3.0'}]
+        {'category': 'critical', 'text':
+         'ER count of 9th (8.9 for -9.9C) mag guide stars 1.57 < 3.0'}]
 
     assert acar.review_status() == -1
 


### PR DESCRIPTION
Update text for "not enough 9th mag stars for ER" with 9th mag equivalent value for t_ccd guide.
I'm not sure about the most succinct format for this info.

Closes #64 