### PR TITLE
Fix issue in naming of roll option plots

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,11 @@ try:
 except ImportError:
     cmdclass = {}
 
-entry_points = {'console_scripts': ['sparkles=sparkles.preview:main']}
+entry_points = {'console_scripts': ['sparkles=sparkles.core:main']}
 
 setup(name='sparkles',
       author='Tom Aldcroft',
-      description='ACA prelim products review',
+      description='Sparkles ACA review package',
       author_email='taldcroft@cfa.harvard.edu',
       version=__version__,
       zip_safe=False,

--- a/sparkles/__init__.py
+++ b/sparkles/__init__.py
@@ -1,5 +1,7 @@
 __version__ = '4.1'
 
+from .core import run_aca_review, ACAReviewTable
+
 
 def test(*args, **kwargs):
     """

--- a/sparkles/__main__.py
+++ b/sparkles/__main__.py
@@ -1,0 +1,2 @@
+from .core import main
+main()

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -376,7 +376,8 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
             del self['idx']
             self.rename_column('idx_temp', 'idx')
 
-    def run_aca_review(self, *, report_dir=None, report_level='none', roll_level='none'):
+    def run_aca_review(self, *, make_html=False, report_dir='.', report_level='none',
+                       roll_level='none'):
         """Do aca review based for this catalog
 
         The ``report_level`` arg specifies the message category at which the full
@@ -386,15 +387,14 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         default is "none", meaning no reports are generated.  A final option is
         "all" which generates a report for every obsid.
 
-        :param report_dir: output directory for report
+        :param make_html: make HTML report (default=False)
+        :param report_dir: output directory for report (default='.')
         :param report_level: report level threshold for generating acq and guide report
         :param roll_level: level threshold for suggesting alternate rolls
 
         :returns: ACAReviewTable object
         """
         acas = [self]
-
-        make_html = (report_dir is not None)
 
         # Do aca review checks and update acas[0] in place
         run_aca_review(load_name=f'Obsid {self.obsid}', acas=acas, make_html=make_html,

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -17,7 +17,6 @@ import matplotlib.pyplot as plt
 from matplotlib.patches import Circle
 
 import numpy as np
-from Quaternion import Quat
 from jinja2 import Template
 from chandra_aca.transform import (yagzag_to_pixels, mag_to_count_rate,
                                    snr_mag_for_t_ccd)
@@ -470,7 +469,7 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         # Note self.roll_options includes the originally-planned roll case
         # as the first row.
         opts = [opt.copy() for opt in self.roll_options]
-        rolls = [Quat(opt['acar'].att).roll for opt in self.roll_options]
+        rolls = [opt['acar'].att.roll for opt in self.roll_options]
         acas = [opt['acar'] for opt in opts]
 
         for opt in opts:
@@ -573,7 +572,7 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
 
         """
         P2 = -np.log10(self.acqs.calc_p_safe())
-        att = Quat(self.att)
+        att = self.att
         self._base_repr_()  # Hack to set default ``format`` for cols as needed
         catalog = '\n'.join(self.pformat(max_width=-1, max_lines=-1))
         self.acq_count = np.sum(self.acqs['p_acq'])

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -113,8 +113,8 @@ def run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=Non
     :param loud: print status information during checking
     :param obsids: list of obsids for selecting a subset for review (mostly for debug)
     :param is_ORs: list of is_OR values (for roll options review page)
-    :param raise_exc: if False then catch exception and return traceback as str
-    :returns: str or None: exception traceback message
+    :param raise_exc: if False then catch exception and return traceback (default=True)
+    :returns: exception message: str or None
 
     """
     try:
@@ -397,7 +397,7 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
             self.rename_column('idx_temp', 'idx')
 
     def run_aca_review(self, *, make_html=False, report_dir='.', report_level='none',
-                       roll_level='none'):
+                       roll_level='none', raise_exc=True):
         """Do aca review based for this catalog
 
         The ``report_level`` arg specifies the message category at which the full
@@ -411,15 +411,18 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         :param report_dir: output directory for report (default='.')
         :param report_level: report level threshold for generating acq and guide report
         :param roll_level: level threshold for suggesting alternate rolls
+        :param raise_exc: if False then catch exception and return traceback (default=True)
+        :returns: exception message: str or None
 
-        :returns: ACAReviewTable object
         """
-        acas = [self]
+        acars = [self]
 
         # Do aca review checks and update acas[0] in place
-        run_aca_review(load_name=f'Obsid {self.obsid}', acars=acas, make_html=make_html,
-                       report_dir=report_dir, report_level=report_level, roll_level=roll_level,
-                       loud=False)
+        exc = run_aca_review(load_name=f'Obsid {self.obsid}', acars=acars, make_html=make_html,
+                             report_dir=report_dir, report_level=report_level,
+                             roll_level=roll_level,
+                             loud=False, raise_exc=raise_exc)
+        return exc
 
     def review_status(self):
         if self.thumbs_up:

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -6,6 +6,7 @@ Preliminary review of ACA catalogs selected by proseco.
 """
 import io
 import re
+import traceback
 from pathlib import Path
 import pickle
 from itertools import combinations, chain
@@ -74,7 +75,8 @@ def main(sys_args=None):
 
 
 def run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=None,
-                   report_level='none', roll_level='none', loud=False, obsids=None):
+                   report_level='none', roll_level='none', loud=False, obsids=None,
+                   raise_exc=True):
     """Do ACA load review based on proseco pickle file from ORviewer.
 
     The ``load_name`` specifies the pickle file from which the ``ACATable``
@@ -111,8 +113,27 @@ def run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=Non
     :param loud: print status information during checking
     :param obsids: list of obsids for selecting a subset for review (mostly for debug)
     :param is_ORs: list of is_OR values (for roll options review page)
+    :param raise_exc: if False then catch exception and return traceback as str
+    :returns: str or None: exception traceback message
 
     """
+    try:
+        _run_aca_review(load_name=load_name, acars=acars, make_html=make_html,
+                        report_dir=report_dir, report_level=report_level,
+                        roll_level=roll_level, loud=loud, obsids=obsids)
+    except Exception:
+        if raise_exc:
+            raise
+        exception = traceback.format_exc()
+    else:
+        exception = None
+
+    return exception
+
+
+def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=None,
+                   report_level='none', roll_level='none', loud=False, obsids=None):
+
     if acars is None:
         acars = get_acas_from_pickle(load_name, loud)
 

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -581,7 +581,7 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         """Make star catalog plot for this observation.
 
         """
-        plotname = f'starcat.png'
+        plotname = f'starcat{self.report_id}.png'
         outfile = self.obsid_dir / plotname
         self.context['catalog_plot'] = outfile.relative_to(self.preview_dir).as_posix()
 

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -19,6 +19,7 @@ from matplotlib.patches import Circle
 
 import numpy as np
 from jinja2 import Template
+from chandra_aca.star_probs import guide_count
 from chandra_aca.transform import (yagzag_to_pixels, mag_to_count_rate,
                                    snr_mag_for_t_ccd)
 from astropy.table import Column, Table
@@ -28,11 +29,9 @@ from proseco.catalog import ACATable
 import proseco.characteristics as ACA
 from proseco.core import MetaAttribute
 
-from . import test as aca_preview_test
-from .roll_optimize import RollOptimizeMixin, guide_count
+from .roll_optimize import RollOptimizeMixin
 
 CACHE = {}
-ACA_PREVIEW_VERSION = aca_preview_test(get_version=True)
 PROSECO_VERSION = proseco.test(get_version=True)
 FILEDIR = Path(__file__).parent
 
@@ -40,9 +39,12 @@ FILEDIR = Path(__file__).parent
 def main(sys_args=None):
     """Command line interface to preview_load()"""
 
+    from . import test
+    version = test(get_version=True)
+
     import argparse
     parser = argparse.ArgumentParser(
-        description=f'ACA preliminary review tool {ACA_PREVIEW_VERSION}')
+        description=f'Sparkles ACA review tool {version}')
     parser.add_argument('load_name',
                         type=str,
                         help='Load name (e.g. JAN2119A) or full file name')
@@ -196,10 +198,12 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
 
     # noinspection PyDictCreation
     if make_html:
+        from . import test
+        sparkles_version = test(get_version=True)
         context = {}
         context['load_name'] = load_name.upper()
         context['proseco_version'] = PROSECO_VERSION
-        context['aca_preview_version'] = ACA_PREVIEW_VERSION
+        context['sparkles_version'] = sparkles_version
         context['acas'] = acars
         context['summary_text'] = get_summary_text(acars)
 
@@ -937,8 +941,3 @@ Predicted Acq CCD temperature (init) : {self.acqs.t_ccd:.1f}"""
         if len(self.fids) != self.n_fid:
             msg = f'Catalog has {len(self.fids)} fids but {self.n_fid} are expected'
             self.add_message('critical', msg)
-
-
-# Run from source ``python -m sparkles.preview <load_name> [options]``
-if __name__ == '__main__':
-    main()

--- a/sparkles/index_template_preview.html
+++ b/sparkles/index_template_preview.html
@@ -52,10 +52,10 @@ span.monospace {
 
   <body>
 
-<h1> {{load_name}} Pre-review</h1>
+<h1> {{load_name}} sparkles review</h1>
 
 <pre>
-aca_preview version: {{aca_preview_version}}
+sparkles version: {{sparkles_version}}
 proseco version: {{proseco_version}}
 
 {{summary_text | safe}}

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -292,7 +292,7 @@ class RollOptimizeMixin:
         # Special case, first roll option is self but with obsid set to roll
         acar = deepcopy(self)
         acar.is_roll_option = True
-        roll_options = [{'aca': acar,
+        roll_options = [{'acar': acar,
                          'P2': P2,
                          'n_stars': n_stars,
                          'improvement': 0.0,
@@ -329,8 +329,8 @@ class RollOptimizeMixin:
             improvement = improve_metric(n_stars, P2, n_stars_rolled, P2_rolled)
 
             if improvement > 0.3:
-                roll_option = {'aca': self.__class__(aca_rolled, obsid=self.obsid,
-                                                     is_roll_option=True),
+                roll_option = {'acar': self.__class__(aca_rolled, obsid=self.obsid,
+                                                      is_roll_option=True),
                                'P2': P2_rolled,
                                'n_stars': n_stars_rolled,
                                'improvement': improvement}

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -150,7 +150,7 @@ class RollOptimizeMixin:
         guides.meta.clear()
         cands = vstack([acqs, guides, self.stars[cols][cand_idxs]])
 
-        q_att = Quat(self.att)
+        q_att = self.att
 
         def get_ids_list(roll_offsets):
             ids_list = []
@@ -286,7 +286,7 @@ class RollOptimizeMixin:
         cand_idxs = self.get_candidate_better_stars()
         roll_intervals, self.roll_info = self.get_roll_intervals(cand_idxs)
 
-        q_att = Quat(self.att)
+        q_att = self.att
         q_targ = calc_targ_from_aca(q_att, 0, 0)
 
         # Special case, first roll option is self but with obsid set to roll

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -9,7 +9,8 @@ from proseco import get_aca_catalog
 from proseco.core import StarsTable
 from proseco.characteristics import CCD
 from proseco.tests.test_common import DARK40, STD_INFO, mod_std_info
-from ..core import ACAReviewTable
+
+from .. import ACAReviewTable
 
 
 def test_check_P2():

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -43,7 +43,8 @@ def test_review_catalog(tmpdir):
     assert acar.review_status() == -1
 
     # Check doing a full review for this obsid
-    acar.run_aca_review(report_dir=tmpdir, roll_level='critical', report_level='critical')
+    acar.run_aca_review(make_html=True, report_dir=tmpdir, report_level='critical',
+                        roll_level='critical')
 
     path = Path(str(tmpdir))
     assert (path / 'index.html').exists()
@@ -80,7 +81,7 @@ def test_review_roll_options(tmpdir):
 
     aca = get_aca_catalog(**kwargs)
     acar = aca.get_review_table()
-    acar.run_aca_review(report_dir=tmpdir, roll_level='critical')
+    acar.run_aca_review(make_html=True, report_dir=tmpdir, roll_level='critical')
 
     assert len(acar.roll_options) == 2
 
@@ -128,7 +129,7 @@ def test_roll_options_with_include_ids():
               'man_angle': 131.2011858838081, 'n_acq': 8, 'n_fid': 0, 'n_guide': 8,
               'sim_offset': 0.0, 'focus_offset': 0.0, 't_ccd_acq': -12.157792574498563,
               't_ccd_guide': -12.17,
-              'include_ids_acq': np.array(
+              'include_ids_acq': np.array(  # Also tests passing float ids for include
                   [8.13042280e+08, 8.13040960e+08, 8.13044168e+08, 8.12911064e+08,
                    8.12920176e+08, 8.12913936e+08, 8.13043216e+08, 8.13045352e+08]),
               'include_halfws_acq': np.array(
@@ -137,3 +138,4 @@ def test_roll_options_with_include_ids():
     aca = get_aca_catalog(**kwargs)
     acar = aca.get_review_table()
     acar.run_aca_review(roll_level='all')
+    assert len(acar.roll_options) > 1

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -56,7 +56,7 @@ def test_review_catalog(tmpdir):
 
 def test_review_roll_options(tmpdir):
     """
-    Test that the 'aca' key in the roll_option dict is an ACAReviewTable
+    Test that the 'acar' key in the roll_option dict is an ACAReviewTable
     and that the first one has the same messages as the base (original roll)
     version
 
@@ -87,10 +87,10 @@ def test_review_roll_options(tmpdir):
 
     # First roll_option is at the same attitude (and roll) as original.  The check
     # code is run again independently but the outcome should be the same.
-    assert acar.roll_options[0]['aca'].messages == acar.messages
+    assert acar.roll_options[0]['acar'].messages == acar.messages
 
     for opt in acar.roll_options:
-        assert isinstance(opt['aca'], ACAReviewTable)
+        assert isinstance(opt['acar'], ACAReviewTable)
 
 
 def test_probs_weak_reference():

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -3,7 +3,7 @@ import pickle
 from pathlib import Path
 
 from proseco import get_aca_catalog
-from ..core import ACAReviewTable
+from ..core import ACAReviewTable, run_aca_review
 
 KWARGS_48464 = {'att': [-0.51759295, -0.30129397, 0.27093045, 0.75360213],
                 'date': '2019:031:13:25:30.000',
@@ -139,3 +139,24 @@ def test_roll_options_with_include_ids():
     acar = aca.get_review_table()
     acar.run_aca_review(roll_level='all')
     assert len(acar.roll_options) > 1
+
+
+def test_catch_exception():
+    exc = run_aca_review(raise_exc=False, load_name='non-existent load name fail fail')
+    assert 'FileNotFoundError: no matching pickle file' in exc
+
+
+def test_run_aca_review_function():
+    aca = get_aca_catalog(**KWARGS_48464)
+    acar = aca.get_review_table()
+    acars = [acar]
+
+    exc = run_aca_review(load_name='test', acars=acars)
+
+    assert exc is None
+    assert acar.messages == [
+        {'text': 'Guide star imposter offset 2.6, limit 2.5 arcsec', 'category': 'warning',
+         'idx': 2},
+        {'text': 'P2: 2.84 less than 3.0 for ER', 'category': 'critical'},
+        {'text': 'ER count of 9th (8.9 for -9.9C) mag guide stars 1.91 < 3.0',
+         'category': 'critical'}]

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 from proseco import get_aca_catalog
-from ..core import ACAReviewTable, run_aca_review
+from .. import ACAReviewTable, run_aca_review
 
 KWARGS_48464 = {'att': [-0.51759295, -0.30129397, 0.27093045, 0.75360213],
                 'date': '2019:031:13:25:30.000',

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -2,6 +2,7 @@ import numpy as np
 import pickle
 from pathlib import Path
 
+import pytest
 from proseco import get_aca_catalog
 from ..core import ACAReviewTable, run_aca_review
 
@@ -141,9 +142,22 @@ def test_roll_options_with_include_ids():
     assert len(acar.roll_options) > 1
 
 
-def test_catch_exception():
+def test_catch_exception_from_function():
     exc = run_aca_review(raise_exc=False, load_name='non-existent load name fail fail')
     assert 'FileNotFoundError: no matching pickle file' in exc
+
+    with pytest.raises(FileNotFoundError):
+        exc = run_aca_review(load_name='non-existent load name fail fail')
+
+
+def test_catch_exception_from_method():
+    aca = get_aca_catalog(**KWARGS_48464)
+    acar = aca.get_review_table()
+    exc = acar.run_aca_review(raise_exc=False, roll_level='BAD VALUE')
+    assert 'ValueError: tuple.index(x): x not in tuple' in exc
+
+    with pytest.raises(ValueError):
+        acar.run_aca_review(roll_level='BAD VALUE')
 
 
 def test_run_aca_review_function():


### PR DESCRIPTION
The roll option plots had previously all wound up with the same name.  This was introduced in the PR that "improved" the roll handling.