### PR TITLE
Populate roll options with messages independent of HTML reporting

### DIFF
--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -291,6 +291,7 @@ class RollOptimizeMixin:
 
         # Special case, first roll option is self but with obsid set to roll
         acar = deepcopy(self)
+        acar.check_catalog()
         acar.is_roll_option = True
         roll_options = [{'acar': acar,
                          'P2': P2,
@@ -329,8 +330,13 @@ class RollOptimizeMixin:
             improvement = improve_metric(n_stars, P2, n_stars_rolled, P2_rolled)
 
             if improvement > 0.3:
-                roll_option = {'acar': self.__class__(aca_rolled, obsid=self.obsid,
-                                                      is_roll_option=True),
+                acar = self.__class__(aca_rolled, obsid=self.obsid,
+                                      is_roll_option=True)
+
+                # Do the review and set up messages attribute
+                acar.check_catalog()
+
+                roll_option = {'acar': acar,
                                'P2': P2_rolled,
                                'n_stars': n_stars_rolled,
                                'improvement': improvement}

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -43,7 +43,15 @@ def test_review_catalog(tmpdir):
 
     assert acar.review_status() == -1
 
+    # Run the review but without making the HTML and ensure review messages
+    # are available on roll options.
+    acar.run_aca_review(roll_level='critical')
+    assert len(acar.roll_options) > 1
+    assert acar.roll_options[0]['acar'].messages == acar.messages
+    assert len(acar.roll_options[1]['acar'].messages) > 0
+
     # Check doing a full review for this obsid
+    acar = aca.get_review_table()
     acar.run_aca_review(make_html=True, report_dir=tmpdir, report_level='critical',
                         roll_level='critical')
 
@@ -82,7 +90,7 @@ def test_review_roll_options(tmpdir):
 
     aca = get_aca_catalog(**kwargs)
     acar = aca.get_review_table()
-    acar.run_aca_review(make_html=True, report_dir=tmpdir, roll_level='critical')
+    acar.run_aca_review(roll_level='critical')
 
     assert len(acar.roll_options) == 2
 

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -63,7 +63,7 @@ def test_review_catalog(tmpdir):
     assert (obspath / 'rolls' / 'index.html').exists()
 
 
-def test_review_roll_options(tmpdir):
+def test_review_roll_options():
     """
     Test that the 'acar' key in the roll_option dict is an ACAReviewTable
     and that the first one has the same messages as the base (original roll)


### PR DESCRIPTION
This continues the morph of a standalone tool that just made a web page into a real thing with user-accessible objects.  The original design wasn't quite ideal for the latter purpose, but we will get there eventually.  Sooner or later I will restructure this code to be more reasonable (without API changes).  In the mean time this should fix #73.

This does end up re-doing the check_catalog() call in the case of making HTML, but that call is so fast compared to making plots etc that I'm not too concerned, at least for now.

Fixes #73 

cc: @jskrist