### PR TITLE
Set make_starcat_plot to always make/remake the images

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -597,9 +597,6 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         outfile = self.obsid_dir / plotname
         self.context['catalog_plot'] = outfile.relative_to(self.preview_dir).as_posix()
 
-        if outfile.exists():
-            return
-
         fig = plt.figure(figsize=(6.75, 6.0))
         ax = fig.add_subplot(1, 1, 1)
         self.plot(ax=ax)


### PR DESCRIPTION
Set make_starcat_plot to always make/remake the images

This cuts the previous optimization that skipped making the plot if it already existed for the observation.  While it might exist, it could be stale.

Closes #81 