### PR TITLE
Fix bug in get_roll_options for small or zero allowed roll deviation

### DIFF
--- a/sparkles/__init__.py
+++ b/sparkles/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '4.1.1'
+__version__ = '4.1.2'
 
 from .core import run_aca_review, ACAReviewTable
 

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -170,7 +170,13 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
         aca.check_catalog()
 
         if roll_level == 'all' or aca.messages >= roll_level:
-            aca.get_roll_options()  # sets roll_options, roll_info attributes
+            try:
+                aca.get_roll_options()  # sets roll_options, roll_info attributes
+            except Exception: # as err:
+                err = traceback.format_exc()
+                aca.add_message('critical', text=f'Running get_roll_options() failed: \n{err}')
+                aca.roll_options = None
+                aca.roll_info = None
 
         if make_html:
 
@@ -186,8 +192,9 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
             if report_level == 'all' or aca.messages >= report_level:
                 try:
                     aca.make_report()
-                except Exception as err:
-                    aca.add_message('critical', text=f'Running make_report() failed: {err}')
+                except Exception:
+                    err = traceback.format_exc()
+                    aca.add_message('critical', text=f'Running make_report() failed:\n{err}')
 
             if aca.roll_info:
                 aca.make_roll_options_report()

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -178,16 +178,19 @@ class RollOptimizeMixin:
         if roll_dev is None:
             roll_dev = allowed_rolldev(pitch)
 
-        # Ensure roll_nom in range 0 <= roll_nom < 360 to match q_att.roll
+        # Ensure roll_nom in range 0 <= roll_nom < 360 to match q_att.roll.
+        # Also ensure that roll_min < roll < roll_max.  It can happen that the
+        # ORviewer scheduled roll is outside the allowed_rolldev() range.  For
+        # far-forward sun, allowed_rolldev() = 0.0.
+        roll = q_att.roll
         roll_nom = roll_nom % 360.0
-        roll_min = roll_nom - roll_dev
-        roll_max = roll_nom + roll_dev
+        roll_min = min(roll_nom - roll_dev, roll - 0.1)
+        roll_max = max(roll_nom + roll_dev, roll + 0.1)
 
         # Get roll offsets spanning roll_min:roll_max with padding.  Padding
         # ensures that if a candidate is best at or beyond the extreme of
         # allowed roll then make sure the sampled rolls go out far enough so
         # that the mean of the roll_offset boundaries will get to the edge.
-        roll = q_att.roll
         ro_minus = np.arange(0, roll_min - roll_dev - roll, -d_roll)[1:][::-1]
         ro_plus = np.arange(0, roll_max + roll_dev - roll, d_roll)
         roll_offsets = np.concatenate([ro_minus, ro_plus])


### PR DESCRIPTION
This problem appeared for a far-forward observation where the allowed roll deviation is exactly 0.0, and the actual scheduled roll ends up being outside the min/max determined by the code.  This caused the index issue because the code requires roll is inside the range.  The fix is just to expand `roll_min` or `roll_max` to be sure `roll` is contained within.

This PR also adds exception handling in the same pattern as for `make_report()`, but does one better by including the full traceback.

To do:
- [ ] Add a test.  I found a way to trigger an exception in get_roll_options() from outside, so will add the test tonight.

For the record these are kwargs that showed the original issue, though the only important ones are attitude and date.
```
{'att': [-0.82389459, -0.1248412, 0.35722113, 0.42190692],
 'date': '2019:073:21:55:30.000',
 'detector': 'ACIS-S',
 'dither_acq': (7.9992, 7.9992),
 'dither_guide': (7.9992, 7.9992),
 'focus_offset': 0.0,
 'man_angle': 122.97035882921071,
 'n_acq': 8,
 'n_fid': 0,
 'n_guide': 8,
 'obsid': 48334.0,
 'sim_offset': 0.0,
 't_ccd_acq': -10.257559323423214,
 't_ccd_guide': -10.25810835536192}
```
And the exception:
```
~/miniconda3/envs/ska3-test/lib/python3.6/site-packages/sparkles/core.py in _run_aca_review(load_name, acars, make_html, report_dir, report_level, roll_level, loud, obsids)
    171 
    172         if roll_level == 'all' or aca.messages >= roll_level:
--> 173             aca.get_roll_options()  # sets roll_options, roll_info attributes
    174 
    175         if make_html:

~/miniconda3/envs/ska3-test/lib/python3.6/site-packages/sparkles/roll_optimize.py in get_roll_options(self)
    285 
    286         cand_idxs = self.get_candidate_better_stars()
--> 287         roll_intervals, self.roll_info = self.get_roll_intervals(cand_idxs)
    288 
    289         q_att = self.att

~/miniconda3/envs/ska3-test/lib/python3.6/site-packages/sparkles/roll_optimize.py in get_roll_intervals(self, cand_idxs, roll_nom, roll_dev, y_off, z_off, d_roll)
    197         # and not roll_nom.
    198         ids_list = get_ids_list(roll_offsets)
--> 199         ids0 = ids_list[len(ro_minus)]
    200 
    201         # Get all unique sets of stars that are in the FOV over the sampled

IndexError: list index out of range
```
