### PR TITLE
Add MetaAttributes so that roll_options, roll_info, and messages get pickled

### DIFF
--- a/sparkles/__init__.py
+++ b/sparkles/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '4.1.1'
+__version__ = '4.1.2'
 
 from .core import run_aca_review, ACAReviewTable
 

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -331,6 +331,8 @@ class MessagesList(list):
 class ACAReviewTable(ACATable, RollOptimizeMixin):
     # Whether this instance is a roll option (controls how HTML report page is formatted)
     is_roll_option = MetaAttribute()
+    roll_options = MetaAttribute()
+    roll_info = MetaAttribute()
 
     def __init__(self, *args, **kwargs):
         """Init review methods and attrs in ``aca`` object *in-place*.

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -170,7 +170,13 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
         aca.check_catalog()
 
         if roll_level == 'all' or aca.messages >= roll_level:
-            aca.get_roll_options()  # sets roll_options, roll_info attributes
+            try:
+                aca.get_roll_options()  # sets roll_options, roll_info attributes
+            except Exception: # as err:
+                err = traceback.format_exc()
+                aca.add_message('critical', text=f'Running get_roll_options() failed: \n{err}')
+                aca.roll_options = None
+                aca.roll_info = None
 
         if make_html:
 
@@ -186,8 +192,9 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
             if report_level == 'all' or aca.messages >= report_level:
                 try:
                     aca.make_report()
-                except Exception as err:
-                    aca.add_message('critical', text=f'Running make_report() failed: {err}')
+                except Exception:
+                    err = traceback.format_exc()
+                    aca.add_message('critical', text=f'Running make_report() failed:\n{err}')
 
             if aca.roll_info:
                 aca.make_roll_options_report()

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -333,6 +333,7 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
     is_roll_option = MetaAttribute()
     roll_options = MetaAttribute()
     roll_info = MetaAttribute()
+    messages = MetaAttribute()
 
     def __init__(self, *args, **kwargs):
         """Init review methods and attrs in ``aca`` object *in-place*.

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -178,16 +178,19 @@ class RollOptimizeMixin:
         if roll_dev is None:
             roll_dev = allowed_rolldev(pitch)
 
-        # Ensure roll_nom in range 0 <= roll_nom < 360 to match q_att.roll
+        # Ensure roll_nom in range 0 <= roll_nom < 360 to match q_att.roll.
+        # Also ensure that roll_min < roll < roll_max.  It can happen that the
+        # ORviewer scheduled roll is outside the allowed_rolldev() range.  For
+        # far-forward sun, allowed_rolldev() = 0.0.
+        roll = q_att.roll
         roll_nom = roll_nom % 360.0
-        roll_min = roll_nom - roll_dev
-        roll_max = roll_nom + roll_dev
+        roll_min = min(roll_nom - roll_dev, roll - 0.1)
+        roll_max = max(roll_nom + roll_dev, roll + 0.1)
 
         # Get roll offsets spanning roll_min:roll_max with padding.  Padding
         # ensures that if a candidate is best at or beyond the extreme of
         # allowed roll then make sure the sampled rolls go out far enough so
         # that the mean of the roll_offset boundaries will get to the edge.
-        roll = q_att.roll
         ro_minus = np.arange(0, roll_min - roll_dev - roll, -d_roll)[1:][::-1]
         ro_plus = np.arange(0, roll_max + roll_dev - roll, d_roll)
         roll_offsets = np.concatenate([ro_minus, ro_plus])


### PR DESCRIPTION
This is based off the `roll-opt-bug` branch.