### PR TITLE
Use target attitude consistently in roll optimization

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -6,6 +6,7 @@ Preliminary review of ACA catalogs selected by proseco.
 """
 import gzip
 import io
+import os
 import re
 import traceback
 from pathlib import Path
@@ -622,15 +623,20 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         """
         P2 = -np.log10(self.acqs.calc_p_safe())
         att = self.att
+        att_targ = self.att_targ
         self._base_repr_()  # Hack to set default ``format`` for cols as needed
         catalog = '\n'.join(self.pformat(max_width=-1, max_lines=-1))
         self.acq_count = np.sum(self.acqs['p_acq'])
+
+        att_string = f'ACA RA, Dec, Roll (deg): {att.ra:.6f} {att.dec:.5f} {att.roll:.5f}'
+        if self.is_OR:
+            att_string += f'  [Target: {att_targ.ra:.6f} {att_targ.dec:.5f} {att_targ.roll:.5f}]'
 
         message_text = self.get_formatted_messages()
 
         text_pre = f"""\
 {self.detector} SIM-Z offset: {self.sim_offset}
-RA, Dec, Roll (deg): {att.ra:.6f} {att.dec:.5f} {att.roll:.5f}
+{att_string}
 Dither acq: Y_amp= {self.dither_acq.y:.1f}  Z_amp={self.dither_acq.z:.1f}
 Dither gui: Y_amp= {self.dither_guide.y:.1f}  Z_amp={self.dither_guide.z:.1f}
 Maneuver Angle: {self.man_angle:.2f}

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -457,6 +457,12 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         return status
 
     @property
+    def att_targ(self):
+        if not hasattr(self, '_att_targ'):
+            self._att_targ = self._calc_targ_from_aca(self.att, 0, 0)
+        return self._att_targ
+
+    @property
     def report_id(self):
         return round(self.att.roll, 2) if self.is_roll_option else self.obsid
 

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -535,6 +535,8 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
 
         for opt in opts:
             del opt['acar']
+            for name in ('add_ids', 'drop_ids'):
+                opt[name] = ' '.join(str(id_) for id_ in opt[name]) if opt[name] else '--'
 
         opts_table = Table(opts, names=['roll', 'P2', 'n_stars', 'improvement',
                                         'roll_min', 'roll_max', 'add_ids', 'drop_ids'])

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -650,9 +650,9 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         catalog = '\n'.join(self.pformat(max_width=-1, max_lines=-1))
         self.acq_count = np.sum(self.acqs['p_acq'])
 
-        att_string = f'ACA RA, Dec, Roll (deg): {att.ra:.6f} {att.dec:.5f} {att.roll:.5f}'
+        att_string = f'ACA RA, Dec, Roll (deg): {att.ra:.5f} {att.dec:.5f} {att.roll:.5f}'
         if self.is_OR:
-            att_string += f'  [Target: {att_targ.ra:.6f} {att_targ.dec:.5f} {att_targ.roll:.5f}]'
+            att_string += f'  [Target: {att_targ.ra:.5f} {att_targ.dec:.5f} {att_targ.roll:.5f}]'
 
         message_text = self.get_formatted_messages()
 

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -464,7 +464,7 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
 
     @property
     def report_id(self):
-        return round(self.att.roll, 2) if self.is_roll_option else self.obsid
+        return round(self.att_targ.roll, 2) if self.is_roll_option else self.obsid
 
     @property
     def thumbs_up(self):

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -214,7 +214,8 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
         # Special case when running a set of roll options for one obsid
         is_roll_report = all(aca.is_roll_option for aca in acars)
 
-        context['id_label'] = 'Roll' if is_roll_report else 'Obsid'
+        label_frame = 'ACA' if aca.is_ER else 'Target'
+        context['id_label'] = f'{label_frame} roll' if is_roll_report else 'Obsid'
 
         template_file = FILEDIR / 'index_template_preview.html'
         template = Template(open(template_file, 'r').read())

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -523,15 +523,14 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         # Get stars from AGASC and set ``stars`` attribute
         self.set_stars(filter_near_fov=False)
 
-    def make_roll_options_report(self):
-        """Make a summary table and separate report page for roll options.
+    def get_roll_options_table(self):
+        """Return table of roll options
+
+        Note that self.roll_options includes the originally-planned roll case
+        as the first row.
 
         """
-        # Note self.roll_options includes the originally-planned roll case
-        # as the first row.
         opts = [opt.copy() for opt in self.roll_options]
-        rolls = [opt['acar'].att.roll for opt in self.roll_options]
-        acas = [opt['acar'] for opt in opts]
 
         for opt in opts:
             del opt['acar']
@@ -543,7 +542,17 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         for col in opts_table.itercols():
             if col.dtype.kind == 'f':
                 col.info.format = '.2f'
-        self.roll_options_table = opts_table
+
+        return opts_table
+
+    def make_roll_options_report(self):
+        """Make a summary table and separate report page for roll options.
+
+        """
+        self.roll_options_table = self.get_roll_options_table()
+
+        # rolls = [opt['acar'].att.roll for opt in self.roll_options]
+        acas = [opt['acar'] for opt in self.roll_options]
 
         # Add in a column with summary of messages in roll options e.g.
         # critical: 2 warning: 1

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -6,7 +6,6 @@ Preliminary review of ACA catalogs selected by proseco.
 """
 import gzip
 import io
-import os
 import re
 import traceback
 from pathlib import Path

--- a/sparkles/index_template_preview.html
+++ b/sparkles/index_template_preview.html
@@ -61,6 +61,13 @@ proseco version: {{proseco_version}}
 {{summary_text | safe}}
 </pre>
 
+{% if roll_options_table %}
+<h3>Roll options (roll_min={{roll_min}}
+        roll_nom={{roll_nom}}
+        roll_max={{roll_max}}</h3>
+        {{roll_options_table | safe}}
+{% endif %}
+
 {% for aca in acas %}
 
 <a name="id{{aca.report_id}}"></a>

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -256,7 +256,16 @@ class RollOptimizeMixin:
 
         return sorted(roll_intervals, key=lambda x: x['roll']), roll_info
 
-    def get_roll_options(self):
+    def get_roll_options(self, min_improvement=0.3):
+        """
+        Get roll options for this catalog.
+
+        This sets the ``roll_options`` attribute with a list of dict, and sets
+        ``roll_info`` with a dict of info about roll.
+
+        :param min_improvement: minimum value of improvement metric to accept option
+        :return: None
+        """
 
         if self.loud:
             print('  Exploring roll options')
@@ -337,7 +346,7 @@ class RollOptimizeMixin:
 
             improvement = improve_metric(n_stars, P2, n_stars_rolled, P2_rolled)
 
-            if improvement > 0.3:
+            if improvement > min_improvement:
                 acar = self.__class__(aca_rolled, obsid=self.obsid,
                                       is_roll_option=True)
 

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -173,11 +173,15 @@ class RollOptimizeMixin:
         # If roll_nom and roll_dev not supplied (which is normally the case) compute
         # them using Sun position.  Here we use the ACA attitude to get pitch since that
         #  is the official "spacecraft" attitude.
+        att = self.att
         if roll_nom is None or roll_dev is None:
             import Ska.Sun
-            pitch = Ska.Sun.pitch(self.att.ra, self.att.dec, self.date)
+            pitch = Ska.Sun.pitch(att.ra, att.dec, self.date)
         if roll_nom is None:
-            roll_nom = Ska.Sun.nominal_roll(self.att.ra, self.att.dec, self.date)
+            roll_nom = Ska.Sun.nominal_roll(att.ra, att.dec, self.date)
+            att_nom = Quat([att.ra, att.dec, roll_nom])
+            att_nom_targ = self._calc_targ_from_aca(att_nom, y_off, z_off)
+            roll_nom = att_nom_targ.roll
         if roll_dev is None:
             roll_dev = allowed_rolldev(pitch)
 

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -131,7 +131,7 @@ class RollOptimizeMixin:
         off-nominal roll) is not specified it is computed using the OFLS table.
         These will not precisely match ORviewer results.
 
-        :param roll_nom: nominal roll for observation (deg)
+        :param roll_nom: nominal target attitude roll for observation (deg)
         :param roll_dev: max allowed deviation from nominal roll (deg)
         :param y_off: Y offset (deg, sign per OR-list convention)
         :param z_off: Z offset (deg, sign per OR-list convention)
@@ -185,7 +185,7 @@ class RollOptimizeMixin:
         if roll_dev is None:
             roll_dev = allowed_rolldev(pitch)
 
-        # Ensure roll_nom in range 0 <= roll_nom < 360 to match q_att.roll.
+        # Ensure roll_nom in range 0 <= roll_nom < 360 to match att_targ.roll.
         # Also ensure that roll_min < roll < roll_max.  It can happen that the
         # ORviewer scheduled roll is outside the allowed_rolldev() range.  For
         # far-forward sun, allowed_rolldev() = 0.0.

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -315,8 +315,8 @@ def test_get_roll_intervals():
     assert acar_er.att.roll <= er_info['roll_max']
     assert acar_er.att.roll >= er_info['roll_min']
 
-    # The roll ranges in ACA rolls should be the same for both the ER and the OR version
-    assert or_info == er_info
+    # The roll ranges in ACA rolls should be different for the ER and the OR version
+    assert or_info != er_info
 
     # Up to this point this is really a weak functional test.  The following asserts
     # are more regression tests for the attitude at obsid 48464

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import pytest
 from proseco import get_aca_catalog
 from Quaternion import Quat
+import Ska.Sun
+from proseco.tests.test_common import mod_std_info
 
 from .. import ACAReviewTable, run_aca_review
 
@@ -214,6 +216,47 @@ def test_roll_outside_range():
     acar.get_roll_options()
     assert Quat(kw['att']).roll <= acar.roll_info['roll_max']
     assert Quat(kw['att']).roll >= acar.roll_info['roll_min']
+
+
+def test_roll_options_dec89_9():
+    """Test getting roll options for an OR and ER at very high declination
+    where the difference between the ACA and target frames is large.  Here
+    the roll will differ by around 10 deg.
+    """
+    dec = 89.9
+    date = '2019:006'
+    roll = Ska.Sun.nominal_roll(0, dec, time=date)
+    att = Quat([0, dec, roll])
+
+    # Expected roll options.  Note same basic outputs for add_ids and drop_ids but
+    # difference roll values.
+    exp = {}
+    exp[48000] = [' roll   P2  n_stars improvement roll_min roll_max  add_ids   drop_ids',
+                  '------ ---- ------- ----------- -------- -------- --------- ---------',
+                  '287.25 3.22    0.55        0.00   287.25   287.25        --        --',
+                  '268.50 7.18    4.98        7.30   268.50   273.25 610927224 606601776',
+                  '270.62 7.18    4.22        6.38   268.50   273.25 610927224        --',
+                  '281.00 7.85    6.98       10.03   276.75   285.25 608567744        --']
+    exp[18000] = [' roll   P2  n_stars improvement roll_min roll_max  add_ids   drop_ids',
+                  '------ ---- ------- ----------- -------- -------- --------- ---------',
+                  '276.94 3.22    7.54        0.00   276.94   276.94        --        --',
+                  '258.19 7.18    8.00        2.05   258.19   262.69 610927224 606601776',
+                  '259.69 7.18    8.00        2.05   258.19   262.69 610927224        --',
+                  '270.57 7.85    8.00        2.39   266.19   274.94 608567744        --']
+
+    for obsid in (48000, 18000):
+        kwargs = mod_std_info(att=att, n_guide=8, obsid=obsid, date=date)
+        # Exclude a bunch of good stars to make the initial catalog lousy
+        exclude_ids = [606470536, 606601760, 606732552, 606732584, 610926712, 611058024]
+        kwargs['exclude_ids_acq'] = exclude_ids
+        kwargs['exclude_ids_guide'] = exclude_ids
+
+        aca = get_aca_catalog(**kwargs)
+        acar = aca.get_review_table()
+        acar.run_aca_review(roll_level='all', make_html=False)
+        tbl = acar.get_roll_options_table()
+        out = tbl.pformat(max_lines=-1, max_width=-1)
+        assert out == exp[obsid]
 
 
 def test_calc_targ_from_aca():


### PR DESCRIPTION
This makes the changes I proposed in #95.  The code changes are actually less than they look because I took the opportunity to make some variable naming more consistent.

But the very important one is that "roll" in the roll info output is **always** the target attitude roll.   For ERs that is the same as the ACA attitude. That's basically what the mission planners want to see.

So by design now there will be a diff between "roll" in the roll options and `acar.roll`, but the roll option roll will match `acar.att_targ.roll`.  Likewise `roll_min` and `roll_max` refer to target attitude roll.

Fixes #95 

cc: @jskrist