### PR TITLE
Improve roll options including uniform sampling of roll range

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -9,11 +9,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.8
     - name: Lint with flake8
       run: |
         pip install flake8
-        flake8 . --count --ignore=W504,E402,F541 --max-line-length=100 --show-source --statistics
+        flake8 . --count --ignore=W503,E402,F541 --max-line-length=100 --show-source --statistics

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -359,6 +359,8 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
     roll_options = MetaAttribute()
     roll_info = MetaAttribute()
     messages = MetaAttribute()
+    target_offset_y = MetaAttribute(default=0.0)
+    target_offset_z = MetaAttribute(default=0.0)
 
     def __init__(self, *args, **kwargs):
         """Init review methods and attrs in ``aca`` object *in-place*.

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -121,6 +121,7 @@ def run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=Non
     - ``min_improvement``: min value of improvement metric to accept option
       (default=0.3)
     - ``d_roll``: delta roll for sampling available roll range (deg, default=0.25)
+    - ``max_roll_dev``: maximum roll deviation (deg, default=max allowed by pitch)
     - ``method``: method for determining roll intervals ('uniq_ids' | 'uniform').
       The 'uniq_ids' method is a faster method that frequently finds an acceptable
       roll option, while 'uniform' is a brute-force search of the entire roll
@@ -212,7 +213,8 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
                 for method in methods:
                     aca.roll_options = None
                     aca.roll_info = None
-                    aca.get_roll_options(roll_level=roll_level, method=method, **roll_args)
+                    aca.get_roll_options(method=method, **roll_args)
+                    aca.roll_info['method'] = method
 
                     # If there is at least one option with no messages at the
                     # roll_level (typically "critical") then declare success and
@@ -506,6 +508,7 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         - ``min_improvement``: min value of improvement metric to accept option
           (default=0.3)
         - ``d_roll``: delta roll for sampling available roll range (deg, default=0.25)
+        - ``max_roll_dev``: maximum roll deviation (deg, default=max allowed by pitch)
         - ``method``: method for determining roll intervals ('uniq_ids' | 'uniform').
           The 'uniq_ids' method is a faster method that frequently finds an acceptable
           roll option, while 'uniform' is a brute-force search of the entire roll

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -402,8 +402,6 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
     roll_options = MetaAttribute()
     roll_info = MetaAttribute()
     messages = MetaAttribute()
-    target_offset_y = MetaAttribute(default=0.0)
-    target_offset_z = MetaAttribute(default=0.0)
 
     def __init__(self, *args, **kwargs):
         """Init review methods and attrs in ``aca`` object *in-place*.
@@ -548,7 +546,7 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
     @property
     def att_targ(self):
         if not hasattr(self, '_att_targ'):
-            self._att_targ = self._calc_targ_from_aca(self.att, 0, 0)
+            self._att_targ = self._calc_targ_from_aca(self.att, *self.target_offset)
         return self._att_targ
 
     @property

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -120,7 +120,8 @@ def run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=Non
 
     - ``min_improvement``: min value of improvement metric to accept option
       (default=0.3)
-    - ``d_roll``: delta roll for sampling available roll range (deg, default=0.25)
+    - ``d_roll``: delta roll for sampling available roll range (deg, default=0.25
+        for uniq_ids method and 0.5 for uniform method)
     - ``max_roll_dev``: maximum roll deviation (deg, default=max allowed by pitch)
     - ``method``: method for determining roll intervals ('uniq_ids' | 'uniform').
       The 'uniq_ids' method is a faster method that frequently finds an acceptable
@@ -515,7 +516,8 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
 
         - ``min_improvement``: min value of improvement metric to accept option
           (default=0.3)
-        - ``d_roll``: delta roll for sampling available roll range (deg, default=0.25)
+        - ``d_roll``: delta roll for sampling available roll range (deg, default=0.25
+            for uniq_ids method and 0.5 for uniform method)
         - ``max_roll_dev``: maximum roll deviation (deg, default=max allowed by pitch)
         - ``method``: method for determining roll intervals ('uniq_ids' | 'uniform').
           The 'uniq_ids' method is a faster method that frequently finds an acceptable

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -127,6 +127,13 @@ def run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=Non
       roll option, while 'uniform' is a brute-force search of the entire roll
       range at ``d_roll`` increments. If not provided, the default is to try
       *both* methods in order, stopping when an acceptable option is found.
+    - ``max_roll_options``: maximum number of roll options to return (default=10)
+
+    If roll options are returned then they are sorted by the following keys:
+
+    - Number of warnings at ``roll_level`` or worse (e.g. number of criticals)
+      in ascending order (fewer is better)
+    - Improvement in descending order (larger improvement is better)
 
     :param load_name: name of loads
     :param acars: list of ACAReviewTable objects (optional)
@@ -224,7 +231,7 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
                            for roll_option in aca.roll_options):
                         break
 
-                        aca.sort_and_limit_roll_options(roll_level, max_roll_options)
+                aca.sort_and_limit_roll_options(roll_level, max_roll_options)
 
             except Exception:  # as err:
                 err = traceback.format_exc()

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -128,7 +128,7 @@ def run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=Non
       roll option, while 'uniform' is a brute-force search of the entire roll
       range at ``d_roll`` increments. If not provided, the default is to try
       *both* methods in order, stopping when an acceptable option is found.
-    - ``max_roll_options``: maximum number of roll options to return (default=20)
+    - ``max_roll_options``: maximum number of roll options to return (default=10)
 
     If roll options are returned then they are sorted by the following keys:
 
@@ -212,7 +212,7 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
         # Find roll options if requested
         if roll_level == 'all' or aca.messages >= roll_level:
             # Get roll selection algorithms to try
-            max_roll_options = roll_args.pop('max_roll_options', 20)
+            max_roll_options = roll_args.pop('max_roll_options', 10)
             methods = roll_args.pop(
                 'method', ('uniq_ids', 'uniform') if aca.is_OR else 'uniq_ids')
             if isinstance(methods, str):

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -181,7 +181,23 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
 
         if roll_level == 'all' or aca.messages >= roll_level:
             try:
-                aca.get_roll_options()  # sets roll_options, roll_info attributes
+                # Set roll_options, roll_info attributes
+                for method in ('uniq_ids', 'uniform'):
+                    aca.get_roll_options(roll_level=roll_level, method=method)
+                    # good_roll = False
+                    # for roll_option in aca.roll_options:
+                    #     if not (roll_option['acar'].messages >= roll_level):
+                    #         good_roll = True
+                    # if good_roll:
+                    #     break
+                    if True:
+                        break
+                    if any(not roll_option['acar'].messages >= roll_level
+                           for roll_option in aca.roll_options):
+                        break
+                    aca.roll_options = None
+                    aca.roll_info = None
+
             except Exception:  # as err:
                 err = traceback.format_exc()
                 aca.add_message('critical', text=f'Running get_roll_options() failed: \n{err}')

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -672,6 +672,7 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         roll_context['roll_options_index'] = rolls_index.as_posix()
         for key in ('roll_min', 'roll_max', 'roll_nom'):
             roll_context[key] = f'{self.roll_info[key]:.2f}'
+        roll_context['roll_method'] = self.roll_info['method']
         self.context.update(roll_context)
 
         # Make a separate preview page for the roll options

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -706,8 +706,8 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         idxs = self.get_candidate_better_stars()
         stars = self.stars[idxs]
         for star in stars:
-            already_checked = ((star['id'] in self.acqs.cand_acqs['id']) and
-                               (star['id'] in self.guides.cand_guides['id']))
+            already_checked = ((star['id'] in self.acqs.cand_acqs['id'])
+                               and (star['id'] in self.guides.cand_guides['id']))
             selected = (star['id'] in set(self.acqs['id']) | set(self.guides['id']))
             if (not already_checked and not selected):
                 circle = Circle((star['row'], star['col']), radius=20,

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -222,8 +222,9 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
                     # stop looking for roll options.
                     if any(not roll_option['acar'].messages >= roll_level
                            for roll_option in aca.roll_options):
-                        aca.sort_and_limit_roll_options(roll_level, max_roll_options)
                         break
+
+                        aca.sort_and_limit_roll_options(roll_level, max_roll_options)
 
             except Exception:  # as err:
                 err = traceback.format_exc()

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -871,6 +871,11 @@ Predicted Acq CCD temperature (init) : {self.t_ccd_acq:.1f}{t_ccd_eff_acq_msg}""
         guide_idxs = np.flatnonzero(ok)
         n_guide = len(guide_idxs)
 
+        if n_guide < 2:
+            msg = f'Cannot check geometry with fewer than 2 guide stars'
+            self.add_message('critical', msg)
+            return
+
         def dist2(g1, g2):
             out = (g1['yang'] - g2['yang']) ** 2 + (g1['zang'] - g2['zang']) ** 2
             return out

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -213,7 +213,8 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
         if roll_level == 'all' or aca.messages >= roll_level:
             # Get roll selection algorithms to try
             max_roll_options = roll_args.pop('max_roll_options', 20)
-            methods = roll_args.pop('method', ('uniq_ids', 'uniform'))
+            methods = roll_args.pop(
+                'method', ('uniq_ids', 'uniform') if aca.is_OR else 'uniq_ids')
             if isinstance(methods, str):
                 methods = [methods]
 

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -204,6 +204,7 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
         # Find roll options if requested
         if roll_level == 'all' or aca.messages >= roll_level:
             # Get roll selection algorithms to try
+            max_roll_options = roll_args.pop('max_roll_options', 10)
             methods = roll_args.pop('method', ('uniq_ids', 'uniform'))
             if isinstance(methods, str):
                 methods = [methods]
@@ -221,6 +222,7 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
                     # stop looking for roll options.
                     if any(not roll_option['acar'].messages >= roll_level
                            for roll_option in aca.roll_options):
+                        aca.sort_and_limit_roll_options(roll_level, max_roll_options)
                         break
 
             except Exception:  # as err:

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -127,7 +127,7 @@ def run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=Non
       roll option, while 'uniform' is a brute-force search of the entire roll
       range at ``d_roll`` increments. If not provided, the default is to try
       *both* methods in order, stopping when an acceptable option is found.
-    - ``max_roll_options``: maximum number of roll options to return (default=10)
+    - ``max_roll_options``: maximum number of roll options to return (default=20)
 
     If roll options are returned then they are sorted by the following keys:
 
@@ -211,7 +211,7 @@ def _run_aca_review(load_name=None, *, acars=None, make_html=True, report_dir=No
         # Find roll options if requested
         if roll_level == 'all' or aca.messages >= roll_level:
             # Get roll selection algorithms to try
-            max_roll_options = roll_args.pop('max_roll_options', 10)
+            max_roll_options = roll_args.pop('max_roll_options', 20)
             methods = roll_args.pop('method', ('uniq_ids', 'uniform'))
             if isinstance(methods, str):
                 methods = [methods]

--- a/sparkles/index_template_preview.html
+++ b/sparkles/index_template_preview.html
@@ -91,7 +91,9 @@ chandra_aca version: {{chandra_aca_version}}
 {% if roll_options_table %}
 <h3>Roll options (roll_min={{roll_min}}
         roll_nom={{roll_nom}}
-        roll_max={{roll_max}}</h3>
+        roll_max={{roll_max}}
+        method={{roll_method}}
+      </h3>)
         {{roll_options_table | safe}}
 {% endif %}
 
@@ -118,7 +120,8 @@ chandra_aca version: {{chandra_aca_version}}
         <h3><a href="{{aca.context['roll_options_index']}}">Roll options
         report</a> (roll_min={{aca.context['roll_min']}}
         roll_nom={{aca.context['roll_nom']}}
-        roll_max={{aca.context['roll_max']}})</h3>
+        roll_max={{aca.context['roll_max']}}
+        method={{aca.context['roll_method']}})</h3>
         {{aca.context['roll_options_table'] | safe}}
         <span>
       {% endif %}

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -342,7 +342,7 @@ class RollOptimizeMixin:
             print(roll_interval)
             roll = roll_interval['roll']
             att_targ_rolled = Quat([att_targ.ra, att_targ.dec, roll])
-            att_rolled = self._calc_aca_from_targ(att_targ_rolled, 0, 0)
+            att_rolled = self._calc_aca_from_targ(att_targ_rolled, *self.target_offset)
 
             kwargs = self.call_args.copy()
 

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -85,8 +85,8 @@ class RollOptimizeMixin:
         # region (mentioned above) between an inner square and outer circle.
         rc_pad = 40
         stars = self.stars
-        in_fov = ((np.abs(stars['row']) < CCD['row_max'] - rc_pad) &
-                  (np.abs(stars['col']) < CCD['col_max'] - rc_pad))
+        in_fov = ((np.abs(stars['row']) < CCD['row_max'] - rc_pad)
+                  & (np.abs(stars['col']) < CCD['col_max'] - rc_pad))
         radius2 = stars['row'] ** 2 + stars['col'] ** 2
         sp_ok = ~in_fov & (radius2 < 2 * (512 + rc_pad) ** 2)
 

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -261,8 +261,6 @@ class RollOptimizeMixin:
             if ids not in uniq_ids_sets and ids - ids0:
                 uniq_ids_sets.append(ids)
 
-        uniq_ids_sets.append(ids0)
-
         # print(f'Roll min, max={roll_min:.2f}, {roll_max:.2f}')
         # For each unique set, find the roll_offset range over which that set
         # is in the FOV.
@@ -305,7 +303,7 @@ class RollOptimizeMixin:
 
         :param min_improvement: minimum value of improvement metric to accept option
         :param d_roll: delta roll for sampling available roll range (deg)
-        :param method: method for determine roll intervals ('uniq_ids' | 'uniform')
+        :param method: method for determining roll intervals ('uniq_ids' | 'uniform')
         :return: None
         """
 

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -313,7 +313,7 @@ class RollOptimizeMixin:
         """
 
         if self.loud:
-            print('  Exploring roll options')
+            print(f' Exploring roll options {method=}')
 
         if self.roll_options is not None:
             warnings.warn('roll_options already available, not re-computing')
@@ -344,7 +344,8 @@ class RollOptimizeMixin:
 
         for roll_interval in roll_intervals:
             if self.loud:
-                print(roll_interval)
+                print(('  roll={roll:.2f} roll_min={roll_min:.2f} roll_max={roll_max:.2f} '
+                       'add_ids={add_ids} drop_ids={drop_ids}').format(**roll_interval))
             roll = roll_interval['roll']
             att_targ_rolled = Quat([att_targ.ra, att_targ.dec, roll])
             att_rolled = self._calc_aca_from_targ(att_targ_rolled, *self.target_offset)
@@ -369,7 +370,7 @@ class RollOptimizeMixin:
 
             improvement = calc_improve_metric(n_stars, P2, n_stars_rolled, P2_rolled)
             if self.loud:
-                print(roll, P2_rolled, n_stars_rolled, improvement)
+                print(f'   {P2_rolled=:.2f} {n_stars_rolled=:.2f} {improvement=:.2f}')
 
             if improvement > min_improvement:
                 acar = self.__class__(aca_rolled, obsid=self.obsid,

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -222,7 +222,6 @@ class RollOptimizeMixin:
                      'roll_max': roll_max,
                      'roll_nom': roll_nom}
 
-        print(roll_intervals)
         return sorted(roll_intervals, key=lambda x: x['roll']), roll_info
 
     @staticmethod
@@ -339,7 +338,8 @@ class RollOptimizeMixin:
                          'drop_ids': set()}]
 
         for roll_interval in roll_intervals:
-            print(roll_interval)
+            if self.loud:
+                print(roll_interval)
             roll = roll_interval['roll']
             att_targ_rolled = Quat([att_targ.ra, att_targ.dec, roll])
             att_rolled = self._calc_aca_from_targ(att_targ_rolled, *self.target_offset)
@@ -363,7 +363,8 @@ class RollOptimizeMixin:
                                          count_9th=self.is_ER)
 
             improvement = calc_improve_metric(n_stars, P2, n_stars_rolled, P2_rolled)
-            print(roll, P2_rolled, n_stars_rolled, improvement)
+            if self.loud:
+                print(roll, P2_rolled, n_stars_rolled, improvement)
 
             if improvement > min_improvement:
                 acar = self.__class__(aca_rolled, obsid=self.obsid,

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -339,7 +339,6 @@ class RollOptimizeMixin:
                          'add_ids': set(),
                          'drop_ids': set()}]
 
-        print(roll_intervals)
         for roll_interval in roll_intervals:
             print(roll_interval)
             roll = roll_interval['roll']
@@ -382,6 +381,27 @@ class RollOptimizeMixin:
                 roll_options.append(roll_option)
 
         self.roll_options = roll_options
+
+    def sort_and_limit_roll_options(self, roll_level, max_roll_options):
+        """Sort the roll options based on two keys:
+        - Number of warnings at roll_level or worse (e.g. number of criticals,
+          so smaller is better)
+        - Negative of improvement (larger improvement is better)
+
+        This updates self.roll_options and also limits the list to a length of
+        ``max_roll_options``.
+
+        The first item is special and corresponds to the baseline roll used
+        by proseco, so it is left in place.
+        """
+        if len(self.roll_options) < 2:
+            return
+
+        def roll_option_sort_key(ro):
+            return (len(ro['acar'].messages >= roll_level), -ro['improvement'])
+
+        ros = sorted(self.roll_options[1:], key=roll_option_sort_key)
+        self.roll_options = ([self.roll_options[0]] + ros)[:max_roll_options]
 
 
 def calc_improve_metric(n_stars, P2, n_stars_new, P2_new):

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -14,6 +14,7 @@ from chandra_aca.star_probs import acq_success_prob, guide_count
 from chandra_aca.transform import (radec_to_yagzag, yagzag_to_pixels,
                                    calc_aca_from_targ, calc_targ_from_aca)
 from Quaternion import Quat
+import Ska.Sun
 
 from proseco.characteristics import CCD
 from proseco import get_aca_catalog
@@ -122,16 +123,19 @@ class RollOptimizeMixin:
         q_out = calc_aca_from_targ(q_att, y_off, z_off) if self.is_OR else q_att
         return q_out
 
-    def get_roll_intervals(self, cand_idxs, roll_nom=None, roll_dev=None,
-                           y_off=0, z_off=0, d_roll=0.25):
+    def get_roll_intervals(self, cand_idxs, y_off=0, z_off=0, d_roll=0.25,
+                           method='uniq_ids'):
         """Find a list of rolls that might substantially improve guide or acq catalogs.
         If ``roll_nom`` is not specified then an approximate value is computed
         via Ska.Sun for the catalog ``date``.  if ``roll_dev`` (max allowed
         off-nominal roll) is not specified it is computed using the OFLS table.
         These will not precisely match ORviewer results.
 
-        :param roll_nom: nominal target attitude roll for observation (deg)
-        :param roll_dev: max allowed deviation from nominal roll (deg)
+        The ``method`` arg specifies the method for finding roll intervals:
+        - 'uniq_ids': find roll intervals over which there is a uniq set of betters stars
+        - 'uniform': roll interval is uniform over allowed range with ``d_roll`` spacing
+
+        :param cand_idxs: index values for candidate better stars
         :param y_off: Y offset (deg, sign per OR-list convention)
         :param z_off: Z offset (deg, sign per OR-list convention)
         :param d_roll: step size for examining roll range (deg, default=0.25)
@@ -139,6 +143,9 @@ class RollOptimizeMixin:
         :returns: list of candidate rolls
 
         """
+        if method not in ('uniq_ids', 'uniform'):
+            raise ValueError('method arg must be "uniq_ids" or "uniform"')
+
         cols = ['id', 'ra', 'dec']
         acqs = Table(self.acqs[cols])
         acqs.meta.clear()
@@ -169,36 +176,31 @@ class RollOptimizeMixin:
                 ids_list.append(set(cands['id'][ok]))
             return ids_list
 
-        # If roll_nom and roll_dev not supplied (which is normally the case) compute
-        # them using Sun position.  Here we use the ACA attitude to get pitch since that
-        #  is the official "spacecraft" attitude.
+        # Compute roll_nom and roll_dev from Sun position.  Here we use the ACA attitude to get
+        # pitch since that is the official "spacecraft" attitude.
         att = self.att
-        if roll_nom is None or roll_dev is None:
-            import Ska.Sun
-            pitch = Ska.Sun.pitch(att.ra, att.dec, self.date)
-        if roll_nom is None:
-            roll_nom = Ska.Sun.nominal_roll(att.ra, att.dec, self.date)
-            att_nom = Quat([att.ra, att.dec, roll_nom])
-            att_nom_targ = self._calc_targ_from_aca(att_nom, y_off, z_off)
-            roll_nom = att_nom_targ.roll
-        if roll_dev is None:
-            roll_dev = allowed_rolldev(pitch)
+        pitch = Ska.Sun.pitch(att.ra, att.dec, self.date)
+        roll_nom = Ska.Sun.nominal_roll(att.ra, att.dec, self.date)
+        att_nom = Quat([att.ra, att.dec, roll_nom])
+        att_nom_targ = self._calc_targ_from_aca(att_nom, y_off, z_off)
+        roll_nom = att_nom_targ.roll
+        roll_dev = allowed_rolldev(pitch)
 
         # Ensure roll_nom in range 0 <= roll_nom < 360 to match att_targ.roll.
         # Also ensure that roll_min < roll < roll_max.  It can happen that the
         # ORviewer scheduled roll is outside the allowed_rolldev() range.  For
         # far-forward sun, allowed_rolldev() = 0.0.
-        roll = att_targ.roll
+        roll_targ = att_targ.roll
         roll_nom = roll_nom % 360.0
-        roll_min = min(roll_nom - roll_dev, roll - 0.1)
-        roll_max = max(roll_nom + roll_dev, roll + 0.1)
+        roll_min = min(roll_nom - roll_dev, roll_targ - 0.1)
+        roll_max = max(roll_nom + roll_dev, roll_targ + 0.1)
 
         # Get roll offsets spanning roll_min:roll_max with padding.  Padding
         # ensures that if a candidate is best at or beyond the extreme of
         # allowed roll then make sure the sampled rolls go out far enough so
         # that the mean of the roll_offset boundaries will get to the edge.
-        ro_minus = np.arange(0, roll_min - roll_dev - roll, -d_roll)[1:][::-1]
-        ro_plus = np.arange(0, roll_max + roll_dev - roll, d_roll)
+        ro_minus = np.arange(0, roll_min - roll_dev - roll_targ, -d_roll)[1:][::-1]
+        ro_plus = np.arange(0, roll_max + roll_dev - roll_targ, d_roll)
         roll_offsets = np.concatenate([ro_minus, ro_plus])
 
         # Get a list of the set of AGASC ids that are in the ACA FOV at each
@@ -207,13 +209,50 @@ class RollOptimizeMixin:
         ids_list = get_ids_list(roll_offsets)
         ids0 = ids_list[len(ro_minus)]
 
+        get_roll_intervals_func = getattr(self, f'_get_roll_intervals_{method}')
+        roll_intervals = get_roll_intervals_func(ids0, ids_list, roll_targ, roll_min,
+                                                 roll_max, roll_offsets, d_roll)
+
+        roll_info = {'roll_min': roll_min,
+                     'roll_max': roll_max,
+                     'roll_nom': roll_nom}
+
+        return sorted(roll_intervals, key=lambda x: x['roll']), roll_info
+
+    @staticmethod
+    def _get_roll_intervals_uniform(ids0, ids_list, roll_targ, roll_min, roll_max,
+                                    roll_offsets, d_roll):
+        """Private method to get uniform set of roll intervals over allowed range.
+        """
+        roll_intervals = []
+        for roll_offset, ids in zip(roll_offsets, ids_list):
+            roll_rolled = roll_targ + roll_offset
+            if roll_rolled < roll_min or roll_rolled > roll_max:
+                continue
+
+            roll_interval = {'roll': roll_rolled,
+                             'roll_min': roll_rolled - d_roll / 2,
+                             'roll_max': roll_rolled + d_roll / 2,
+                             'add_ids': ids - ids0,
+                             'drop_ids': ids0 - ids}
+
+            roll_intervals.append(roll_interval)
+
+        return roll_intervals
+
+    @staticmethod
+    def _get_roll_intervals_uniq_ids(ids0, ids_list, roll, roll_max, roll_min,
+                                     roll_offsets, d_roll):
+        """Private method to get roll intervals that span a range where there is a unique
+        set of available candidate stars within the entire interval.
+
+        """
         # Get all unique sets of stars that are in the FOV over the sampled
         # roll offsets.  Ignore ids sets that do not add new candidate stars.
         uniq_ids_sets = []
         for ids in ids_list:
             if ids not in uniq_ids_sets and ids - ids0:
                 uniq_ids_sets.append(ids)
-
         # print(f'Roll min, max={roll_min:.2f}, {roll_max:.2f}')
         # For each unique set, find the roll_offset range over which that set
         # is in the FOV.
@@ -248,14 +287,9 @@ class RollOptimizeMixin:
                     roll_interval[key] = np.clip(roll_interval[key], roll_min, roll_max)
 
                 roll_intervals.append(roll_interval)
+        return roll_intervals
 
-        roll_info = {'roll_min': roll_min,
-                     'roll_max': roll_max,
-                     'roll_nom': roll_nom}
-
-        return sorted(roll_intervals, key=lambda x: x['roll']), roll_info
-
-    def get_roll_options(self, min_improvement=0.3):
+    def get_roll_options(self, min_improvement=-300, d_roll=1, method='uniform'):
         """
         Get roll options for this catalog.
 
@@ -263,6 +297,8 @@ class RollOptimizeMixin:
         ``roll_info`` with a dict of info about roll.
 
         :param min_improvement: minimum value of improvement metric to accept option
+        :param d_roll: delta roll for sampling available roll range (deg)
+        :param method: method for determine roll intervals ('uniq_ids' | 'uniform')
         :return: None
         """
 
@@ -302,7 +338,8 @@ class RollOptimizeMixin:
         n_stars = guide_count(self.guides['mag'], self.guides.t_ccd, self.is_ER)
 
         cand_idxs = self.get_candidate_better_stars()
-        roll_intervals, self.roll_info = self.get_roll_intervals(cand_idxs)
+        roll_intervals, self.roll_info = self.get_roll_intervals(
+            cand_idxs, d_roll=d_roll, method=method)
 
         att_targ = self.att_targ
 

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -294,7 +294,7 @@ class RollOptimizeMixin:
         return roll_intervals
 
     def get_roll_options(self, min_improvement=0.3, d_roll=0.25, method='uniq_ids',
-                         max_roll_dev=None, roll_level='critical'):
+                         max_roll_dev=None):
         """
         Get roll options for this catalog.
 
@@ -304,6 +304,8 @@ class RollOptimizeMixin:
         :param min_improvement: minimum value of improvement metric to accept option
         :param d_roll: delta roll for sampling available roll range (deg)
         :param method: method for determining roll intervals ('uniq_ids' | 'uniform')
+        :param max_roll_dev: maximum roll deviation from nominal (default=max allowed by fish plot)
+
         :return: None
         """
 

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -256,7 +256,7 @@ class RollOptimizeMixin:
         """
         # Get all unique sets of stars that are in the FOV over the sampled
         # roll offsets.  Ignore ids sets that do not add new candidate stars.
-        uniq_ids_sets = []
+        uniq_ids_sets = [ids0]
         for ids in ids_list:
             if ids not in uniq_ids_sets and ids - ids0:
                 uniq_ids_sets.append(ids)

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -123,7 +123,7 @@ class RollOptimizeMixin:
         q_out = calc_aca_from_targ(q_att, y_off, z_off) if self.is_OR else q_att
         return q_out
 
-    def get_roll_intervals(self, cand_idxs, d_roll=0.25, roll_dev=None,
+    def get_roll_intervals(self, cand_idxs, d_roll=None, roll_dev=None,
                            method='uniq_ids', max_roll_dev=None):
         """Find a list of rolls that might substantially improve guide or acq catalogs.
         If ``roll_nom`` is not specified then an approximate value is computed
@@ -138,13 +138,17 @@ class RollOptimizeMixin:
         :param cand_idxs: index values for candidate better stars
         :param y_off: Y offset (deg, sign per OR-list convention)
         :param z_off: Z offset (deg, sign per OR-list convention)
-        :param d_roll: step size for examining roll range (deg, default=0.25)
+        :param d_roll: step size for examining roll range (deg, default=0.25 for
+                       uniq_ids and 0.5 for uniform)
 
         :returns: list of candidate rolls
 
         """
         if method not in ('uniq_ids', 'uniform'):
             raise ValueError('method arg must be "uniq_ids" or "uniform"')
+
+        if d_roll is None:
+            d_roll = {'uniq_ids': 0.25, 'uniform': 0.5}[method]
 
         cols = ['id', 'ra', 'dec']
         acqs = Table(self.acqs[cols])
@@ -291,7 +295,7 @@ class RollOptimizeMixin:
                 roll_intervals.append(roll_interval)
         return roll_intervals
 
-    def get_roll_options(self, min_improvement=0.3, d_roll=0.25, method='uniq_ids',
+    def get_roll_options(self, min_improvement=0.3, d_roll=None, method='uniq_ids',
                          max_roll_dev=None):
         """
         Get roll options for this catalog.
@@ -300,7 +304,8 @@ class RollOptimizeMixin:
         ``roll_info`` with a dict of info about roll.
 
         :param min_improvement: minimum value of improvement metric to accept option
-        :param d_roll: delta roll for sampling available roll range (deg)
+        :param d_roll: delta roll for sampling available roll range (deg, default=0.25 for uniq_ids
+                       and 0.5 for uniform method)
         :param method: method for determining roll intervals ('uniq_ids' | 'uniform')
         :param max_roll_dev: maximum roll deviation from nominal (default=max allowed by fish plot)
 

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -166,8 +166,7 @@ class RollOptimizeMixin:
                 att_targ_rolled = Quat([att_targ.ra, att_targ.dec, att_targ.roll + roll_offset])
 
                 # Transform back to ACA pointing for computing star positions.
-                att_rolled = self._calc_aca_from_targ(
-                    att_targ_rolled, self.target_offset_y, self.target_offset_z)
+                att_rolled = self._calc_aca_from_targ(att_targ_rolled, *self.target_offset)
 
                 # Get yag/zag row/col for candidates
                 yag, zag = radec_to_yagzag(cands['ra'], cands['dec'], att_rolled)
@@ -183,7 +182,7 @@ class RollOptimizeMixin:
         pitch = Ska.Sun.pitch(att.ra, att.dec, self.date)
         roll_nom = Ska.Sun.nominal_roll(att.ra, att.dec, self.date)
         att_nom = Quat([att.ra, att.dec, roll_nom])
-        att_nom_targ = self._calc_targ_from_aca(att_nom, self.target_offset_y, self.target_offset_z)
+        att_nom_targ = self._calc_targ_from_aca(att_nom, *self.target_offset)
         roll_nom = att_nom_targ.roll
 
         if roll_dev is None:

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -180,6 +180,35 @@ def test_roll_options_with_include_ids():
     # assert len(acar.roll_options) > 1
 
 
+def test_uniform_roll_options():
+    """Use obsid 22508 as a test case for failing to find a roll option using
+    the 'uniq_ids' algorithm and falling through to a 'uniform' search.
+
+    See https://github.com/sot/sparkles/issues/138 for context.
+    """
+    kwargs = {'att': [-0.25019352, -0.90540872, -0.21768747, 0.26504794],
+              'date': '2020:045:18:19:50.234',
+              'detector': 'ACIS-S',
+              'dither': 8.0,
+              'focus_offset': 0,
+              'man_angle': 1.56,
+              'obsid': 22508,
+              'sim_offset': 0,
+              't_ccd_acq': -9.8,
+              't_ccd_guide': -9.8}
+
+    aca = get_aca_catalog(**kwargs)
+    acar = aca.get_review_table()
+    acar.run_aca_review(roll_level='critical', roll_args={'max_roll_dev': 2.5})
+
+    # Fell through to uniform roll search
+    assert acar.roll_info['method'] == 'uniform'
+
+    # Found at least one roll option with no critical messages
+    assert any(len(roll_option['acar'].messages >= 'critical') == 0
+               for roll_option in acar.roll_options)
+
+
 def test_catch_exception_from_function():
     exc = run_aca_review(raise_exc=False, load_name='non-existent load name fail fail')
     assert 'FileNotFoundError: no matching pickle file' in exc

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -409,11 +409,31 @@ def test_get_roll_intervals():
                     assert interv[key] == exp_interv[key]
 
     # For the OR we expect this
-    or_exp_intervs = [{'add_ids': set(),
+    or_exp_intervs = [{'add_ids': {84943288},
+                       'drop_ids': {84937736},
+                       'roll': 281.53501733258395,
+                       'roll_max': 281.57597660655892,
+                       'roll_min': 281.53501733258395},
+                      {'add_ids': set(),
                        'drop_ids': set(),
-                       'roll': 284.42476093331379,
+                       'roll': 289.07597660655892,
                        'roll_max': 291.53501733258395,
-                       'roll_min': 281.53501733258395}]
+                       'roll_min': 283.82597660655892},
+                      {'add_ids': {84941648},
+                       'drop_ids': set(),
+                       'roll': 289.07597660655892,
+                       'roll_max': 290.32597660655892,
+                       'roll_min': 287.82597660655892},
+                      {'add_ids': {85328120, 84941648},
+                       'drop_ids': set(),
+                       'roll': 289.82597660655892,
+                       'roll_max': 290.32597660655892,
+                       'roll_min': 289.32597660655892},
+                      {'add_ids': {85328120},
+                       'drop_ids': set(),
+                       'roll': 291.53501733258395,
+                       'roll_max': 291.53501733258395,
+                       'roll_min': 289.32597660655892}]
     compare_intervs(or_roll_intervs, or_exp_intervs)
 
     # For the ER we expect these

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -121,7 +121,7 @@ def test_review_roll_options():
     acar = aca.get_review_table()
     acar.run_aca_review(roll_level='critical')
 
-    assert len(acar.roll_options) == 2
+    assert len(acar.roll_options) == 3
 
     # First roll_option is at the same attitude (and roll) as original.  The check
     # code is run again independently but the outcome should be the same.
@@ -298,14 +298,16 @@ def test_roll_options_dec89_9():
                   '287.25 3.61    0.55        0.00   287.25   287.25        --        --',
                   '268.50 6.82    4.98        6.93   268.50   273.25 610927224 606601776',
                   '270.62 6.82    4.22        6.01   268.50   273.25 610927224        --',
-                  '281.00 7.44    6.98        9.64   276.75   285.25 608567744        --']
+                  '281.00 7.44    6.98        9.64   276.75   285.25 608567744        --',
+                  '287.50 7.25    5.43        7.68   268.50   306.00        --        --']
 
     exp[18000] = [' roll   P2  n_stars improvement roll_min roll_max  add_ids   drop_ids',
                   '------ ---- ------- ----------- -------- -------- --------- ---------',
                   '276.94 3.61    7.54        0.00   276.94   276.94        --        --',
                   '258.19 6.82    8.00        1.68   258.19   262.69 610927224 606601776',
                   '259.69 6.82    8.00        1.68   258.19   262.69 610927224        --',
-                  '270.57 7.44    8.00        1.99   266.19   274.94 608567744        --']
+                  '270.57 7.44    8.00        1.99   266.19   274.94 608567744        --',
+                  '277.07 7.25    8.00        1.89   258.19   295.69        --        --']
 
     for obsid in (48000, 18000):
         kwargs = mod_std_info(att=att, n_guide=8, obsid=obsid, date=date)

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -323,6 +323,8 @@ def test_get_roll_intervals():
     obs_kwargs = KWARGS_48464
     aca_er = get_aca_catalog(**obs_kwargs)
     acar_er = aca_er.get_review_table()
+    acar_er.target_offset_y = 20 / 60.
+    acar_er.target_offset_z = 30 / 60.
 
     kw_or = obs_kwargs.copy()
     # Set this one to have an OR obsid (and not 0 which is special)
@@ -332,17 +334,17 @@ def test_get_roll_intervals():
 
     # Use these values to override the get_roll_intervals ranges to get more interesting
     # outputs.  y_off and z_off are really 0 everywhere for now from ORViewer though.
-    y_off = 20 / 60.
-    z_off = 30 / 60.
+    acar_or.target_offset_y = 20 / 60.
+    acar_or.target_offset_z = 30 / 60.
     roll_dev = 5
 
     er_roll_intervs, er_info = acar_er.get_roll_intervals(
         acar_er.get_candidate_better_stars(),
-        roll_dev=roll_dev, y_off=y_off, z_off=z_off)
+        roll_dev=roll_dev)
 
     or_roll_intervs, or_info = acar_or.get_roll_intervals(
         acar_or.get_candidate_better_stars(),
-        roll_dev=roll_dev, y_off=y_off, z_off=z_off)
+        roll_dev=roll_dev)
 
     assert acar_er.att.roll <= er_info['roll_max']
     assert acar_er.att.roll >= er_info['roll_min']

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -394,6 +394,7 @@ def test_get_roll_intervals():
     # Set a function to do some looping and isclose logic to compare
     # the actual vs expected intervals.
     def compare_intervs(intervs, exp_intervs):
+        assert len(intervs) == len(exp_intervs)
         for interv, exp_interv in zip(intervs, exp_intervs):
             assert interv.keys() == exp_interv.keys()
             for key in interv.keys():
@@ -403,27 +404,27 @@ def test_get_roll_intervals():
                     assert interv[key] == exp_interv[key]
 
     # For the OR we expect this
-    or_exp_intervs = [{'roll': 281.63739755173594,
-                       'roll_min': 281.63739755173594,
-                       'roll_max': 281.67838289905592,
-                       'add_ids': {84943288},
-                       'drop_ids': {84937736}},
-                      {'roll': 291.63739755173594,
-                       'roll_min': 289.42838289905592,
-                       'roll_max': 291.63739755173594,
-                       'add_ids': {85328120},
-                       'drop_ids': set()}]
+    or_exp_intervs = [{'add_ids': set(),
+                       'drop_ids': set(),
+                       'roll': 284.42476093331379,
+                       'roll_max': 291.53501733258395,
+                       'roll_min': 281.53501733258395}]
     compare_intervs(or_roll_intervs, or_exp_intervs)
 
     # For the ER we expect these
-    er_exp_intervs = [{'roll': 291.63739755173594,
-                       'roll_min': 289.67838289905592,
+    er_exp_intervs = [{'add_ids': set(),
+                       'drop_ids': set(),
+                       'roll': 290.80338289905592,
                        'roll_max': 291.63739755173594,
-                       'add_ids': {84943288},
-                       'drop_ids': set()},
-                      {'roll': 291.63739755173594,
-                       'roll_min': 290.92838289905592,
+                       'roll_min': 285.17838289905592},
+                      {'add_ids': {84943288},
+                       'drop_ids': set(),
+                       'roll': 291.63739755173594,
                        'roll_max': 291.63739755173594,
-                       'add_ids': {85328120, 84943288},
-                       'drop_ids': set()}]
+                       'roll_min': 289.67838289905592},
+                      {'add_ids': {85328120, 84943288},
+                       'drop_ids': set(),
+                       'roll': 291.63739755173594,
+                       'roll_max': 291.63739755173594,
+                       'roll_min': 290.92838289905592}]
     compare_intervs(er_roll_intervs, er_exp_intervs)

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -72,15 +72,17 @@ def test_review_catalog(tmpdir):
 
     # Run the review but without making the HTML and ensure review messages
     # are available on roll options.
-    acar.run_aca_review(roll_level='critical')
+    acar.run_aca_review(roll_level='critical', roll_args={'method': 'uniq_ids'})
     assert len(acar.roll_options) > 1
     assert acar.roll_options[0]['acar'].messages == acar.messages
     assert len(acar.roll_options[1]['acar'].messages) > 0
+    for roll_option in acar.roll_options[1:]:
+        print(roll_option['acar'].messages)
 
     # Check doing a full review for this obsid
     acar = aca.get_review_table()
     acar.run_aca_review(make_html=True, report_dir=tmpdir, report_level='critical',
-                        roll_level='critical')
+                        roll_level='critical', roll_args={'method': 'uniq_ids'})
 
     path = Path(str(tmpdir))
     assert (path / 'index.html').exists()
@@ -117,7 +119,7 @@ def test_review_roll_options():
 
     aca = get_aca_catalog(**kwargs)
     acar = aca.get_review_table()
-    acar.run_aca_review(roll_level='critical')
+    acar.run_aca_review(roll_level='critical') # , roll_args={'method': 'uniq_ids'})
 
     assert len(acar.roll_options) == 2
 
@@ -173,7 +175,7 @@ def test_roll_options_with_include_ids():
 
     aca = get_aca_catalog(**kwargs)
     acar = aca.get_review_table()
-    acar.run_aca_review(roll_level='all')
+    acar.run_aca_review(roll_level='all', roll_args={'method': 'uniq_ids'})
     # As of the 2020-02 acq model update there is just one roll option
     # assert len(acar.roll_options) > 1
 
@@ -285,7 +287,7 @@ def test_roll_options_dec89_9():
 
         aca = get_aca_catalog(**kwargs)
         acar = aca.get_review_table()
-        acar.run_aca_review(roll_level='all', make_html=False)
+        acar.run_aca_review(roll_level='all', roll_args={'method': 'uniq_ids'}, make_html=False)
         tbl = acar.get_roll_options_table()
         out = tbl.pformat(max_lines=-1, max_width=-1)
         assert out == exp[obsid]

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -119,7 +119,7 @@ def test_review_roll_options():
 
     aca = get_aca_catalog(**kwargs)
     acar = aca.get_review_table()
-    acar.run_aca_review(roll_level='critical') # , roll_args={'method': 'uniq_ids'})
+    acar.run_aca_review(roll_level='critical')
 
     assert len(acar.roll_options) == 2
 

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -208,6 +208,15 @@ def test_uniform_roll_options():
     assert any(len(roll_option['acar'].messages >= 'critical') == 0
                for roll_option in acar.roll_options)
 
+    assert len(acar.roll_options) == 5
+
+    # Now limit the number of roll options
+    acar = aca.get_review_table()
+    acar.run_aca_review(roll_level='critical',
+                        roll_args={'max_roll_dev': 2.5, 'max_roll_options': 3})
+    assert len(acar.roll_options) == 3
+
+
 
 def test_catch_exception_from_function():
     exc = run_aca_review(raise_exc=False, load_name='non-existent load name fail fail')

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -197,7 +197,8 @@ def test_uniform_roll_options():
 
     aca = get_aca_catalog(**kwargs)
     acar = aca.get_review_table()
-    acar.run_aca_review(roll_level='critical', roll_args={'max_roll_dev': 2.5})
+    acar.run_aca_review(roll_level='critical', roll_args={'max_roll_dev': 2.5,
+                                                          'd_roll': 0.25})
 
     # Fell through to uniform roll search
     assert acar.roll_info['method'] == 'uniform'
@@ -211,7 +212,8 @@ def test_uniform_roll_options():
     # Now limit the number of roll options
     acar = aca.get_review_table()
     acar.run_aca_review(roll_level='critical',
-                        roll_args={'max_roll_dev': 2.5, 'max_roll_options': 3})
+                        roll_args={'max_roll_dev': 2.5, 'max_roll_options': 3,
+                                   'd_roll': 0.25})
     assert len(acar.roll_options) == 3
 
 
@@ -302,18 +304,18 @@ def test_roll_options_dec89_9():
     exp[48000] = [' roll   P2  n_stars improvement roll_min roll_max  add_ids   drop_ids',
                   '------ ---- ------- ----------- -------- -------- --------- ---------',
                   '287.25 3.61    0.55        0.00   287.25   287.25        --        --',
-                  '268.50 6.82    4.98        6.93   268.50   273.25 610927224 606601776',
-                  '270.62 6.82    4.22        6.01   268.50   273.25 610927224        --',
                   '281.00 7.44    6.98        9.64   276.75   285.25 608567744        --',
-                  '287.50 7.25    5.43        7.68   268.50   306.00        --        --']
+                  '287.50 7.25    5.43        7.68   268.50   306.00        --        --',
+                  '268.50 6.82    4.98        6.93   268.50   273.25 610927224 606601776',
+                  '270.62 6.82    4.22        6.01   268.50   273.25 610927224        --']
 
     exp[18000] = [' roll   P2  n_stars improvement roll_min roll_max  add_ids   drop_ids',
                   '------ ---- ------- ----------- -------- -------- --------- ---------',
                   '276.94 3.61    7.54        0.00   276.94   276.94        --        --',
-                  '258.19 6.82    8.00        1.68   258.19   262.69 610927224 606601776',
-                  '259.69 6.82    8.00        1.68   258.19   262.69 610927224        --',
                   '270.57 7.44    8.00        1.99   266.19   274.94 608567744        --',
-                  '277.07 7.25    8.00        1.89   258.19   295.69        --        --']
+                  '277.07 7.25    8.00        1.89   258.19   295.69        --        --',
+                  '258.19 6.82    8.00        1.68   258.19   262.69 610927224 606601776',
+                  '259.69 6.82    8.00        1.68   258.19   262.69 610927224        --']
 
     for obsid in (48000, 18000):
         kwargs = mod_std_info(att=att, n_guide=8, obsid=obsid, date=date)

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -217,7 +217,6 @@ def test_uniform_roll_options():
     assert len(acar.roll_options) == 3
 
 
-
 def test_catch_exception_from_function():
     exc = run_aca_review(raise_exc=False, load_name='non-existent load name fail fail')
     assert 'FileNotFoundError: no matching pickle file' in exc
@@ -362,11 +361,12 @@ def test_get_roll_intervals():
 
     # This uses the catalog at KWARGS_48464, but would really be better as a fully
     # synthetic test
-    obs_kwargs = KWARGS_48464
+    obs_kwargs = KWARGS_48464.copy()
+    # Use these values to override the get_roll_intervals ranges to get more interesting
+    # outputs.
+    obs_kwargs['target_offset'] = (20 / 60., 30 / 60)  # deg
     aca_er = get_aca_catalog(**obs_kwargs)
     acar_er = aca_er.get_review_table()
-    acar_er.target_offset_y = 20 / 60.
-    acar_er.target_offset_z = 30 / 60.
 
     kw_or = obs_kwargs.copy()
     # Set this one to have an OR obsid (and not 0 which is special)
@@ -374,10 +374,6 @@ def test_get_roll_intervals():
     aca_or = get_aca_catalog(**kw_or)
     acar_or = aca_or.get_review_table()
 
-    # Use these values to override the get_roll_intervals ranges to get more interesting
-    # outputs.  y_off and z_off are really 0 everywhere for now from ORViewer though.
-    acar_or.target_offset_y = 20 / 60.
-    acar_or.target_offset_z = 30 / 60.
     roll_dev = 5
 
     er_roll_intervs, er_info = acar_er.get_roll_intervals(

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -76,8 +76,6 @@ def test_review_catalog(tmpdir):
     assert len(acar.roll_options) > 1
     assert acar.roll_options[0]['acar'].messages == acar.messages
     assert len(acar.roll_options[1]['acar'].messages) > 0
-    for roll_option in acar.roll_options[1:]:
-        print(roll_option['acar'].messages)
 
     # Check doing a full review for this obsid
     acar = aca.get_review_table()


### PR DESCRIPTION
## Description

This implements a fall-through option to uniformly sample the entire roll range in cases when the faster algorithm fails to find a solution with no criticals.

It is also improves the original algorithm by including the roll interval corresponding to the original MP-requested roll, but using a roll at the center of the roll interval.  The "roll interval" means the full range in roll where the set of candidate stars is unchanged. In the testing below, two of the three obsids were improved because of this change.

A final update is to order the roll options in descending order of improvement, basically putting the best options (from the ACA perspective) first.

## Review

- [x] FOT MP review and acceptance of functional test results (@jayhead13 on Slack, June 15 in aspect)
- [x] SOT aspect review of functional test results and code

## Testing

A number of observations where identified by FOT MP as problematic during the planning process, requiring some special handling and possibly failing to find a good roll option. Several of these (21486, 21172, 23129, 21867) seemed to be OK now, possibly related to the newer acquisition probability model. However, sparkles 4.6.0 did in fact fail to find a good roll option for three observations, shown below.  With this PR, a good option was found in all cases. Obsid 22508 is the one example where the uniform roll option finding was required.

### Obsid 21706
- [Flight 4.6.0 roll options](https://cxc.cfa.harvard.edu/mta/ASPECT/tests/sparkles/pr106/roll_4.6.0/21706/index.html)
- [Dev roll options](https://cxc.cfa.harvard.edu/mta/ASPECT/tests/sparkles/pr106/roll_4.6.1.dev25+gc3f147a/21706/index.html)

### Obsid 22508
- [Flight 4.6.0 roll options](https://cxc.cfa.harvard.edu/mta/ASPECT/tests/sparkles/pr106/roll_4.6.0/22508/index.html)
- [Dev roll options](https://cxc.cfa.harvard.edu/mta/ASPECT/tests/sparkles/pr106/roll_4.6.1.dev25+gc3f147a/22508/index.html)

### Obsid 20922
- [Flight 4.6.0 roll options](https://cxc.cfa.harvard.edu/mta/ASPECT/tests/sparkles/pr106/roll_4.6.0/20922/index.html)
- [Dev roll options](https://cxc.cfa.harvard.edu/mta/ASPECT/tests/sparkles/pr106/roll_4.6.1.dev25+gc3f147a/20922/index.html)

### APR0620A

The entire APR0620A schedule was run:
https://cxc.harvard.edu/mta/ASPECT/tests/sparkles/pr106/APR0620A_sparkles/

### Test script for individual OR's

The script below was used to generate the test outputs. In all cases this used a dev version of proseco that allows setting the `target_offset` (https://github.com/sot/proseco/pull/328). This is required for this PR.

```
import os
import sys
import shutil
from pathlib import Path
from pprint import pprint

sys.path.insert(0, str(Path.home() / 'git' / 'proseco'))

from proseco import get_aca_catalog
import sparkles
from astropy.table import Table
from mica.starcheck import get_starcheck_catalog
from chandra_aca.transform import calc_aca_from_targ
import Ska.Sun

obsid = int(sys.argv[1])

sc = get_starcheck_catalog(obsid)
oflsdir = Path(os.environ['SKA']) / 'data/mpcrit1/mplogs' / sc['mp_dir'][1:]

dynoff = list(oflsdir.glob('*dynamical_offsets.txt'))[0]
dynoffs = Table.read(dynoff, format='ascii')
dynoffs.add_index('obsid')
obs = dynoffs.loc[obsid]

targ_ra, targ_dec = obs['target_ra'], obs['target_dec']
y_off = (obs['target_offset_y'] + obs['aca_offset_y']) / 3600
z_off = (obs['target_offset_z'] + obs['aca_offset_z']) / 3600
targ_roll_nom = Ska.Sun.nominal_roll(targ_ra, targ_dec, obs['mean_date'])
att_aca_nom = calc_aca_from_targ((targ_ra, targ_dec, targ_roll_nom), y_off, z_off)  # nominal roll

aca = get_aca_catalog(obsid=obsid, att=att_aca_nom, target_offset=(y_off, z_off))
acar = aca.get_review_table()

outdir = Path.cwd() / f'roll_{sparkles.__version__}' / str(obsid)
if outdir.exists():
    shutil.rmtree(outdir)
outdir.mkdir(parents=True)

print(f'Running review for obsid={obsid} at {att_aca_nom.equatorial} into {outdir}')
pprint(acar.call_args)

acar.run_aca_review(make_html=True, report_dir=str(outdir), roll_level='critical')
```


Fixes #138 