### PR TITLE
Check the number of guides and fids selected vs expected and typical

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -856,17 +856,6 @@ Predicted Acq CCD temperature (init) : {self.acqs.t_ccd:.1f}"""
         elif P2 < P2_lim + 1:
             self.add_message('warning', f'P2: {P2:.2f} less than {P2_lim + 1} for {obs_type}')
 
-    def check_n_guide(self):
-        """Check for "typical" number of fids for an OR or ER (3 or 0)
-        """
-        typical_n_guide = 5 if self.is_OR else 8
-        n_guide = len(self.guides)
-        if n_guide != typical_n_guide:
-            msg = f'Catalog has {n_guide} guides but {typical_n_guide} is typical'
-            if self.is_OR and n_guide == 4:
-                msg += f' (could be MON star? Check OR list)'
-            self.add_message('caution', msg)
-
     def check_guide_count(self):
         """
         Check for sufficient guide star fractional count.
@@ -894,6 +883,23 @@ Predicted Acq CCD temperature (init) : {self.acqs.t_ccd:.1f}"""
             self.add_message(
                 'caution',
                 f'{obs_type} with more than {bright_cnt_lim} stars brighter than 6.1.')
+
+        n_guide = len(self.guides)
+
+        # Different number of guide stars than requested
+        if n_guide != self.n_guide:
+            self.add_message(
+                'caution',
+                f'{obs_type} with {n_guide} guides but {self.n_guide} were requested')
+
+        # Caution for any "unusual" guide star request
+        typical_n_guide = 5 if self.is_OR else 8
+        if self.n_guide != typical_n_guide:
+            msg = f'{obs_type} with {n_guide} guides requested but {typical_n_guide} is typical'
+            if self.is_OR and n_guide == 4:
+                msg += f' (likely MON star, check OR list)'
+            self.add_message('caution', msg)
+
 
     def check_pos_err_guide(self, star):
         """Warn on stars with larger POS_ERR (warning at 1" critical at 2")
@@ -996,16 +1002,14 @@ Predicted Acq CCD temperature (init) : {self.acqs.t_ccd:.1f}"""
 
         :return: None
         """
-        if self.n_fid == 0:
-            return
+        obs_type = 'ER' if self.is_ER else 'OR'
 
         if len(self.fids) != self.n_fid:
-            msg = f'Catalog has {len(self.fids)} fids but {self.n_fid} were requested'
+            msg = f'{obs_type} has {len(self.fids)} fids but {self.n_fid} were requested'
             self.add_message('critical', msg)
 
         # Check for "typical" number of fids for an OR / ER (3 or 0)
         typical_n_fid = 3 if self.is_OR else 0
-        n_fid = len(self.fids)
-        if n_fid != typical_n_fid:
-            msg = f'Catalog has {n_fid} fids but {typical_n_fid} is typical'
+        if self.n_fid != typical_n_fid:
+            msg = f'{obs_type} requested {self.n_fid} fids but {typical_n_fid} is typical'
             self.add_message('caution', msg)

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -856,6 +856,17 @@ Predicted Acq CCD temperature (init) : {self.acqs.t_ccd:.1f}"""
         elif P2 < P2_lim + 1:
             self.add_message('warning', f'P2: {P2:.2f} less than {P2_lim + 1} for {obs_type}')
 
+    def check_n_guide(self):
+        """Check for "typical" number of fids for an OR or ER (3 or 0)
+        """
+        typical_n_guide = 5 if self.is_OR else 8
+        n_guide = len(self.guides)
+        if n_guide != typical_n_guide:
+            msg = f'Catalog has {n_guide} guides but {typical_n_guide} is typical'
+            if self.is_OR and n_guide == 4:
+                msg += f' (could be MON star? Check OR list)'
+            self.add_message('caution', msg)
+
     def check_guide_count(self):
         """
         Check for sufficient guide star fractional count.
@@ -989,5 +1000,12 @@ Predicted Acq CCD temperature (init) : {self.acqs.t_ccd:.1f}"""
             return
 
         if len(self.fids) != self.n_fid:
-            msg = f'Catalog has {len(self.fids)} fids but {self.n_fid} are expected'
+            msg = f'Catalog has {len(self.fids)} fids but {self.n_fid} were requested'
             self.add_message('critical', msg)
+
+        # Check for "typical" number of fids for an OR / ER (3 or 0)
+        typical_n_fid = 3 if self.is_OR else 0
+        n_fid = len(self.fids)
+        if n_fid != typical_n_fid:
+            msg = f'Catalog has {n_fid} fids but {typical_n_fid} is typical'
+            self.add_message('caution', msg)

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -41,7 +41,7 @@ def test_check_P2():
 
 
 def test_n_guide_check_not_enough_stars():
-    """Test the check that number of guide stars selected is typical"""
+    """Test the check that number of guide stars selected is as requested"""
 
     stars = StarsTable.empty()
     stars.add_fake_constellation(n_stars=4, mag=8.5)

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -40,6 +40,20 @@ def test_check_P2():
     assert 'less than 3.0 for ER' in msg['text']
 
 
+def test_n_guide_check():
+    """Test the check that number of guide stars selected is typical"""
+
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(n_stars=8, mag=8.5)
+    aca = get_aca_catalog(**mod_std_info(n_fid=3, n_guide=4, obsid=5000),
+                          stars=stars, dark=DARK40,
+                          raise_exc=True)
+    acar = ACAReviewTable(aca)
+    acar.check_guide_count()
+    assert acar.messages == [
+        {'text': 'Catalog has 4 guide stars but 5 is typical.', 's'}
+    ]
+
 def test_guide_count_er():
     """Test the check that an ER has enough fractional guide stars by guide_count"""
 
@@ -298,7 +312,23 @@ def test_check_fid_count():
     acar.check_catalog()
 
     assert acar.messages == [
-        {'text': 'Catalog has 2 fids but 3 are expected', 'category': 'critical'}]
+        {'text': 'Catalog has 2 fids but 3 were requested', 'category': 'critical'},
+        {'text': 'Catalog has 2 fids but 3 is typical', 'category': 'caution'}]
+
+
+def test_check_fid_count_fid():
+    """Test checking fid count"""
+    stars = StarsTable.empty()
+    # def add_fake_stars_from_fid(self, fid_id=1, offset_y=0, offset_z=0, mag=7.0,
+    #                            id=None, detector='ACIS-S', sim_offset=0):
+    stars.add_fake_constellation(n_stars=8)
+
+    aca = get_aca_catalog(stars=stars, **mod_std_info(detector='HRC-S', n_fid=2))
+    acar = ACAReviewTable(aca)
+    acar.check_catalog()
+
+    assert acar.messages == [
+        {'text': 'Catalog has 2 fids but 3 is typical', 'category': 'caution'}]
 
 
 def test_check_guide_geometry():

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -35,7 +35,8 @@ def test_review_catalog(tmpdir):
          'idx': 2},
         {'text': 'P2: 2.84 less than 3.0 for ER', 'category': 'critical'},
         {'text': 'ER count of 9th (8.9 for -9.9C) mag guide stars 1.91 < 3.0',
-         'category': 'critical'}]
+         'category': 'critical'},
+        {'text': 'ER with 6 guides but 8 were requested', 'category': 'caution'}]
 
     assert acar.roll_options is None
 
@@ -185,7 +186,8 @@ def test_run_aca_review_function():
          'idx': 2},
         {'text': 'P2: 2.84 less than 3.0 for ER', 'category': 'critical'},
         {'text': 'ER count of 9th (8.9 for -9.9C) mag guide stars 1.91 < 3.0',
-         'category': 'critical'}]
+         'category': 'critical'},
+        {'text': 'ER with 6 guides but 8 were requested', 'category': 'caution'}]
 
 
 def test_roll_outside_range():


### PR DESCRIPTION
This incorporates #84 and expands on the idea, in particular adding a caution that would indicate the likely presence of a MON star in the observation.  It also adds the missing test for #84 plus a few more.