### PR TITLE
Add GitHub action for flake8 checking

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,19 @@
+name: Python flake8 check
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        flake8 . --count --ignore=W504 --max-line-length=100 --show-source --statistics


### PR DESCRIPTION
For this repo the only required ignore is W504 which just means that it *allows* line break after a binary operator but will flag line break before binary operator.  This is the standard convention, but older repos that don't pass can also ignore W503 so that either convention is OK.

I realized that E402 (code intermixed with top-level imports) should always be checked, so I have dropped that from the standard list of ignores.  In cases where it is needed (e.g. `matplotlib.use('Agg')` then put a `# noqa`.