### PR TITLE
Add check that guide star is a valid guide candidate

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -736,6 +736,7 @@ Predicted Acq CCD temperature (init) : {self.t_ccd_acq:.1f}{t_ccd_eff_acq_msg}""
                 self.check_pos_err_guide(star)
                 self.check_imposters_guide(star)
                 self.check_too_bright_guide(star)
+                self.check_guide_is_candidate(star)
 
             if is_guide or is_acq:
                 self.check_bad_stars(entry)
@@ -961,6 +962,19 @@ Predicted Acq CCD temperature (init) : {self.t_ccd_acq:.1f}{t_ccd_eff_acq_msg}""
                     f'Guide star imposter offset {offset:.1f}, limit {limit} arcsec',
                     idx=idx)
                 break
+
+    def check_guide_is_candidate(self, star):
+        """Critical for guide star that is not a valid guide candidate.
+
+        This can occur for a manually included guide star.  In rare cases
+        the star may still be acceptable and ACA review can accept the warning.
+        """
+        if not self.guides.get_candidates_mask(star):
+            agasc_id = star['id']
+            idx = self.get_id(agasc_id)['idx']
+            self.add_message(
+                'critical',
+                f'Guide star {agasc_id} does not meet guide candidate criteria', idx=idx)
 
     def check_too_bright_guide(self, star):
         """Warn on guide stars that may be too bright.

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -54,6 +54,25 @@ def test_n_guide_check_not_enough_stars():
          'category': 'caution'}]
 
 
+def test_guide_is_candidate():
+    """Test the check that guide star meets candidate star requirements
+
+    Make a star catalog with a CLASS=3 star and force include it for guide.
+    """
+
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(n_stars=6, mag=8.5, CLASS=[3, 0, 0, 0, 0, 0])
+    aca = get_aca_catalog(**mod_std_info(n_fid=3, n_guide=5, obsid=5000),
+                          stars=stars, dark=DARK40, include_ids_guide=[100],
+                          raise_exc=True)
+    acar = ACAReviewTable(aca)
+    acar.check_catalog()
+    assert acar.messages == [
+        {'text': 'Guide star 100 does not meet guide candidate criteria',
+         'category': 'critical',
+         'idx': 8}]
+
+
 def test_n_guide_check_atypical_request():
     """Test the check that number of guide stars selected is typical"""
 
@@ -283,6 +302,8 @@ def test_bad_star_set():
     acar = ACAReviewTable(aca)
     acar.check_catalog()
     assert acar.messages == [
+        {'text': 'Guide star 1248994952 does not meet guide candidate criteria',
+         'category': 'critical', 'idx': 5},
         {'text': 'Star 1248994952 is in proseco bad star set', 'category': 'critical', 'idx': 5},
         {'text': 'OR requested 0 fids but 3 is typical', 'category': 'caution'}]
 


### PR DESCRIPTION
This does not provide the detailed reason (which is difficult because the criteria are programmatically coded in proseco), but does give a critical for a guide star that is not a valid candidate.

Closes #132
