### PR TITLE
formatted callargs HTML id to be consistent between JavaScript and HTML

### DIFF
--- a/sparkles/index_template_preview.html
+++ b/sparkles/index_template_preview.html
@@ -69,7 +69,7 @@ span.monospace {
     <script>
 
       function hideShow(num) {
-        var x = document.getElementById("callargs" + num);
+        var x = document.getElementById("callargs" + num.toFixed(2));
         if (x.classList.contains('hidden')) {
           x.classList.replace('hidden', 'shown');
         } else {
@@ -106,7 +106,7 @@ chandra_aca version: {{chandra_aca_version}}
   <tr>
     <td>
       <button onclick="hideShow({{aca.report_id}})">Show/hide call args</button>
-      <div id="callargs{{aca.report_id}}" class="callargs hidden">{{aca.context['call_args']}}
+      <div id="callargs{{'%1.2f' % aca.report_id}}" class="callargs hidden">{{aca.context['call_args']}}
       </div>
     </td>
   </tr>


### PR DESCRIPTION
## Description
The HTML report generated by running a review has a button that is supposed to show or hide the arguments used to call sparkles, however, this button can fail to work sometimes.  This PR fixes an issue with this button.

The id of the callargs HTML Element does not always match the id being looked for in the JavaScript function.  For example, the HTML Element id might be "callargs12345.0" and the JavaScript was looking for an element with the id "callargs12345".  When this happens, the JavaScript throws an error and the show/hide button doesn't do anything. 

## Testing

- [x] Passes unit tests on Windows
> ============================= test session starts =============================
> platform win32 -- Python 3.6.2, pytest-3.7.4, py-1.6.0, pluggy-0.7.1
> rootdir: <FOT_TOOLS_ROOT>\Python\python3_Windows_64bit_Dev\lib\site-packages\sparkles-4.6.1.dev4+g357d00e-py3.6.egg, inifile:
> plugins: remotedata-0.3.0, openfiles-0.3.0, doctestplus-0.1.3, arraydiff-0.2
> collected 32 items
> 
> sparkles\tests\test_checks.py ....................                       [ 62%]
> sparkles\tests\test_review.py ............                               [100%]
> 
> ========================= 32 passed in 41.14 seconds ==========================
- [X] Functional testing
Ran ORViewer and found Stars with proseco and sparkles.  Then looked at the generated html file in Chrome and tested the button while looking at the browser's console for any errors or warnings.  None were seen.  The test passed.


