### PR TITLE
Support slicing of ACAReviewTable

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -434,6 +434,12 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         # Make a copy of input aca table along with a deepcopy of its meta.
         super().__init__(*args, **kwargs)
 
+        # If no data were provided then skip all the rest of the initialization.
+        # This happens during slicing. The result is not actually
+        # a functional ACAReviewTable, but it allows inspection of data.
+        if len(self.colnames) == 0:
+            return
+
         self.is_roll_option = is_roll_option
 
         # Add row and col columns from yag/zag, if not already there.

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -12,6 +12,19 @@ from proseco.tests.test_common import DARK40, STD_INFO, mod_std_info
 from .. import ACAReviewTable
 
 
+def test_check_slice_index():
+    """Test slice and index"""
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(n_stars=8, mag=10.25)
+    aca = get_aca_catalog(**STD_INFO, stars=stars, dark=DARK40)
+    acar = aca.get_review_table()
+    for item in (1, slice(5, 10)):
+        acar1 = acar[item]
+        assert acar1.colnames == acar.colnames
+        for name in acar1.colnames:
+            assert np.all(acar1[name] == acar[name][item])
+
+
 def test_check_P2():
     """Test the check of acq P2"""
     stars = StarsTable.empty()


### PR DESCRIPTION
## Description

This fixes #150 by allowing creation of an empty `ACAReviewTable` which can then be constructed by the normal `Table` slicing machinery. The resultant object is not a full-fledged `ACAReviewTable` and you cannot run review methods and such on it. I think it would be possible to do this if there were a real driver, but it would require overriding `__getitem__` and might get messy.

## Testing

- [x] Passes unit tests on MacOS with new unit test
- [N/A] Functional testing

Fixes #150