### PR TITLE
Improve checks with proseco monitors capability

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1048,10 +1048,8 @@ Predicted Acq CCD temperature (init) : {self.t_ccd_acq:.1f}{t_ccd_eff_acq_msg}""
 
         # Caution for any "unusual" guide star request
         typical_n_guide = 5 if self.is_OR else 8
-        if self.n_guide != typical_n_guide:
+        if self.n_guide + len(self.mons) != typical_n_guide:
             msg = f'{obs_type} with {n_guide} guides requested but {typical_n_guide} is typical'
-            if self.is_OR and n_guide == 4:
-                msg += f' (likely MON star, check OR list)'
             self.add_message('caution', msg)
 
     def check_pos_err_guide(self, star):

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -99,7 +99,7 @@ def test_n_guide_check_atypical_request():
     acar = ACAReviewTable(aca)
     acar.check_guide_count()
     assert acar.messages == [
-        {'text': 'OR with 4 guides requested but 5 is typical (likely MON star, check OR list)',
+        {'text': 'OR with 4 guides requested but 5 is typical',
          'category': 'caution'}]
 
 


### PR DESCRIPTION
## Description

The sparkles n_guide test was not cognizant of proseco having the monitor star handling capability, which is fixed here. This PR also adds a test of a typical monitor window request to ensure no warnings are issued.

## Testing

- [x] Passes unit tests on MacOS (updated and new tests)
- [n/a] Functional testing
