### PR TITLE
Fix test failure from PR #159

### DIFF
--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -217,6 +217,7 @@ def test_uniform_roll_options():
     kwargs = {'att': [-0.25019352, -0.90540872, -0.21768747, 0.26504794],
               'date': '2020:045:18:19:50.234',
               'detector': 'ACIS-S',
+              'n_guide': 5,
               'n_fid': 3,
               'dither': 8.0,
               'focus_offset': 0,


### PR DESCRIPTION
## Description

PR #159 was unfortunately merged without actually passing unit tests. This fixes the problem.

It does highlight again that the munging of `n_guide` and fact that it doesn't correspond to the input argument is not ideal. In this case the test was not fully specifying the required arguments (in particular `n_guide`) and was "helpfully" dealing with that by going to the mica starcheck archive to discover the right value for `n_guide`. This process then misses having `n_guide` in the `call_args`.

In production this is not really a problem because all the required args are specified or else the obsid is not in the archive.

See also: https://github.com/sot/proseco/pull/366

## Testing

- [x] Passes unit tests on MacOS
- [n/a] Functional testing
