### PR TITLE
Update roll review test for up to 5.2 mag stars

### DIFF
--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -126,7 +126,7 @@ def test_review_roll_options():
     acar = aca.get_review_table()
     acar.run_aca_review(roll_level='critical')
 
-    assert len(acar.roll_options) == 3
+    assert len(acar.roll_options) == 4
 
     # First roll_option is at the same attitude (and roll) as original.  The check
     # code is run again independently but the outcome should be the same.


### PR DESCRIPTION
## Description

Update roll review test for up to 5.2 mag stars

With the change in proseco to allow up-to-5.2 mag star selection, the test_review_roll_options test now has a new option with a 5.4 mag BOT star.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing - this change is a functional test update
