### PR TITLE
Add mag for candidates + fix minor plot() bug

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -730,7 +730,8 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         :param kwargs: other keyword args for plot_stars
         """
         fig = super().plot(ax, **kwargs)
-        ax = fig.gca()
+        if ax is None:
+            ax = fig.gca()
 
         # Increase plot bounds to allow seeing stars within a 750 pixel radius
         ax.set_xlim(-770, 770)  # pixels

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -754,6 +754,8 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
                 circle = Circle((star['row'], star['col']), radius=20,
                                 facecolor='none', edgecolor='r', alpha=0.8, lw=1.5)
                 ax.add_patch(circle)
+                ax.text(star['row'] + 24, star['col'], f'{star["mag"]:.2f}',
+                        ha='left', va='center', fontsize='small', color='r')
 
     def make_starcat_plot(self):
         """Make star catalog plot for this observation.


### PR DESCRIPTION
## Description

This adds text that indicates the magnitude of candidate stars in a sparkles plot. This was useful in the Jiang DDT evaluations.

It also fixes a bug I noticed in the `plot` method where the input `ax` arg was being ignored. The jupyter notebook run was a test of this.

## Interface impact

This changes the plot output to add more information but otherwise does not change any impact of code execution.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing

```
from proseco import get_aca_catalog
import matplotlib.pyplot as plt
%matplotlib 
# %matplotlib widget in jupyter notebook
aca = get_aca_catalog(8008)
acar = aca.get_review_table()
fig, ax = plt.subplots(figsize=(6, 6))
acar.plot(ax=ax)  # did this a second time in another cell and it plotted in the original ax
```

<img width="492" alt="image" src="https://user-images.githubusercontent.com/348089/159910979-a423cf87-b9cd-460e-b5ee-7bcd818cdf43.png">
