### PR TITLE
Allow opening a pickle from Noodle/OCCweb

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -48,7 +48,8 @@ def main(sys_args=None):
     parser.add_argument('load_name',
                         type=str,
                         help=('Load name (e.g. JAN2119A) or full file name or directory '
-                              r'on \\noodle\GRETA\mission or OCCweb containing a single pickle file, '
+                              r'on \\noodle\GRETA\mission or OCCweb '
+                              r'containing a single pickle file, '
                               r'or a Noodle path (beginning with \\noodle\GRETA\mission) '
                               'or OCCweb path to a gzip pickle file'))
     parser.add_argument('--obsid',
@@ -376,7 +377,6 @@ def get_acas_dict_from_local_file(load_name, loud):
 def get_acas_dict_from_occweb(path):
     """ Get pickle file from OCCweb"""
     from kadi.occweb import get_occweb_dir, get_occweb_page
-    path = path.replace('//noodle/GRETA/mission/', 'FOT/mission_planning/')
 
     if not path.endswith('.pkl.gz'):
         occweb_files = get_occweb_dir(path)
@@ -414,10 +414,7 @@ def get_acas_from_pickle(load_name, loud=False):
     :param load_name: load name
     :param loud: print processing information
     """
-    # Translate load name like `\\noodle\GRETA` to '//noodle/GRETA'
-    load_name = load_name.replace('\\', '/')
-
-    if load_name.startswith('//noodle') or load_name.startswith('https://occweb'):
+    if load_name.startswith(r'\\noodle') or load_name.startswith('https://occweb'):
         acas_dict, path_name = get_acas_dict_from_occweb(load_name)
     else:
         acas_dict, path_name = get_acas_dict_from_local_file(load_name, loud)

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -382,7 +382,11 @@ def get_acas_dict_from_occweb(path):
         occweb_files = get_occweb_dir(path)
         pkl_files = [name for name in occweb_files['Name'] if name.endswith('.pkl.gz')]
         if len(pkl_files) > 1:
-            raise ValueError(f'Found multiple pickle files in {path}')
+            print(f'Found multiple pickle files for {path}:')
+            for i, pkl_file in enumerate(pkl_files):
+                print(f'  {i}: {pkl_file}')
+            choice = input('Enter choice: ')
+            pkl_files = [pkl_files[int(choice)]]
         elif len(pkl_files) == 0:
             raise ValueError(f'No pickle files found in {path}')
         path = path + '/' + pkl_files[0]


### PR DESCRIPTION
## Description

Prelim pickles are often provided just as a Noodle directory where the file lives. This can take a few clicks to unwind, so this PR allows providing just the path that is provided.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None (but more flexibility in specifying `load_name` option).

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

```
(ska3-2022.4) ➜  sparkles git:(open-from-noodle) ✗ python -m sparkles '\\noodle\GRETA\mission\Backstop\ScheduleWorkspaces\MAY0922\aca' --open-html
Processing obsid 45509
Processing obsid 45508
...
Processing obsid 25290
Processing obsid 45488
Writing output review file MAY0922_ACA_prelim_2022_117_10_48_40_240_sparkles/index.html
Open URL in browser: file:///Users/aldcroft/git/sparkles/MAY0922_ACA_prelim_2022_117_10_48_40_240_sparkles/index.html
```
```
(ska3-2022.4) ➜  sparkles git:(open-from-noodle) ✗ python -m sparkles '\\noodle\GRETA\mission\Backstop\ScheduleWorkspaces\MAY0922\aca\MAY0922_ACA_prelim_2022_117_10_48_40_240.pkl.gz'        
Processing obsid 45509
Processing obsid 45508
...
Processing obsid 25290
Processing obsid 45488
Writing output review file MAY0922_ACA_prelim_2022_117_10_48_40_240_sparkles/index.html
```
```
(ska3-2022.4) ➜  sparkles git:(open-from-noodle) ✗ python -m sparkles https://occweb.cfa.harvard.edu/occweb/FOT/mission_planning/Backstop/ScheduleWorkspaces/MAY0922/aca/
Processing obsid 45509
Processing obsid 45508
...
Processing obsid 25290
Processing obsid 45488
Writing output review file MAY0922_ACA_prelim_2022_117_10_48_40_240_sparkles/index.html```
```

```
(ska3-2022.4) ➜  sparkles git:(open-from-noodle) ✗ python -m sparkles https://occweb.cfa.harvard.edu/occweb/FOT/mission_planning/Backstop/ScheduleWorkspaces/MAY0922/aca/MAY0922_ACA_prelim_2022_117_10_48_40_240.pkl.gz
Processing obsid 45509
Processing obsid 45508
...
Processing obsid 25290
Processing obsid 45488
Writing output review file MAY0922_ACA_prelim_2022_117_10_48_40_240_sparkles/index.html```
```
```
(ska3-2022.4) ➜  sparkles git:(open-from-noodle) ✗ python -m sparkles junk/APR2020P_2020_100_13_02_31_705.pkl.gz
Reading pickle file junk/APR2020P_2020_100_13_02_31_705.pkl.gz
Processing obsid 47275
Processing obsid 47274
...
Processing obsid -13153
Processing obsid 22544.1
Writing output review file APR2020P_2020_100_13_02_31_705_sparkles/index.html
```
```
(ska3-2022.4) ➜  sparkles git:(open-from-noodle) ✗ python -m sparkles junk/APR2020P_2020_100_13_02_31_705       
Reading pickle file junk/APR2020P_2020_100_13_02_31_705.pkl.gz
Processing obsid 47275
Processing obsid 47274
...
Processing obsid -13153
Processing obsid 22544.1
Writing output review file APR2020P_2020_100_13_02_31_705_sparkles/index.html
```
#### Multiple files
I could not find a directory on noodle with multiple pickle files, so for this test I temporarily modified the code to run the selection block for `len(pkl_files) >= 1` instead of `len(pkl_files) > 1`:
```
(ska3-2022.4) ➜  sparkles git:(open-from-noodle) ✗ python -m sparkles '\\noodle\GRETA\mission\Backstop\ScheduleWorkspaces\MAY0922\aca'
Found multiple pickle files for \\noodle\GRETA\mission\Backstop\ScheduleWorkspaces\MAY0922\aca:
  0: MAY0922_ACA_prelim_2022_117_10_48_40_240.pkl.gz
Enter choice: 0
Processing obsid 45509
Processing obsid 45508
...
Processing obsid 25290
Processing obsid 45488
Writing output review file MAY0922_ACA_prelim_2022_117_10_48_40_240_sparkles/index.html
```