### PR TITLE
Update guide bright count check

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1139,10 +1139,10 @@ Predicted Acq CCD temperature (init) : {self.t_ccd_acq:.1f}{t_ccd_eff_acq_msg}""
                 f'{obs_type} count of guide stars {self.guide_count:.2f} < {count_lim}')
 
         bright_cnt_lim = 1 if self.is_OR else 3
-        if np.count_nonzero(self.guides['mag'] < 6.1) > bright_cnt_lim:
+        if np.count_nonzero(self.guides['mag'] < 5.5) > bright_cnt_lim:
             self.add_message(
                 'caution',
-                f'{obs_type} with more than {bright_cnt_lim} stars brighter than 6.1.')
+                f'{obs_type} with more than {bright_cnt_lim} stars brighter than 5.5.')
 
         # Requested slots for guide stars and mon windows
         n_guide_or_mon_request = self.call_args['n_guide']

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1139,7 +1139,7 @@ Predicted Acq CCD temperature (init) : {self.t_ccd_acq:.1f}{t_ccd_eff_acq_msg}""
                 f'{obs_type} count of guide stars {self.guide_count:.2f} < {count_lim}')
 
         bright_cnt_lim = 1 if self.is_OR else 3
-        if np.count_nonzero(self['mag'] < 6.1) > bright_cnt_lim:
+        if np.count_nonzero(self.guides['mag'] < 6.1) > bright_cnt_lim:
             self.add_message(
                 'caution',
                 f'{obs_type} with more than {bright_cnt_lim} stars brighter than 6.1.')

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -246,9 +246,9 @@ def test_include_exclude():
 
 def test_guide_count_er5():
     # This configuration should warn with too many bright stars
-    # (has > 3.0 stars brighter than 6.1
+    # (has > 3.0 stars brighter than 5.5
     stars = StarsTable.empty()
-    stars.add_fake_constellation(n_stars=4, mag=6.0)
+    stars.add_fake_constellation(n_stars=4, mag=5.4)
     stars.add_fake_star(yang=1000, zang=1000, mag=8.0)
     stars.add_fake_star(yang=-1000, zang=1000, mag=8.0)
     aca = get_aca_catalog(**mod_std_info(obsid=50000, n_fid=0, n_guide=8), stars=stars, dark=DARK40,
@@ -256,7 +256,7 @@ def test_guide_count_er5():
     aca = ACAReviewTable(aca)
     aca.check_guide_count()
     assert aca.messages == [
-        {'text': 'ER with more than 3 stars brighter than 6.1.', 'category': 'caution'},
+        {'text': 'ER with more than 3 stars brighter than 5.5.', 'category': 'caution'},
         {'text': 'ER with 6 guides but 8 were requested', 'category': 'caution'}]
 
 
@@ -273,10 +273,10 @@ def test_guide_count_or():
         {'text': 'OR with 2 guides but 5 were requested', 'category': 'caution'}]
 
     # This configuration should not warn with too many really bright stars
-    # (allowed to have 1 stars brighter than 6.1)
+    # (allowed to have 1 stars brighter than 5.5)
     stars = StarsTable.empty()
     stars.add_fake_constellation(n_stars=3, mag=8.0)
-    stars.add_fake_star(yang=100, zang=100, mag=6.0)
+    stars.add_fake_star(yang=100, zang=100, mag=5.4)
     aca = get_aca_catalog(**mod_std_info(n_fid=3, n_guide=5, obsid=1), stars=stars, dark=DARK40,
                           raise_exc=True)
     aca = ACAReviewTable(aca)
@@ -285,11 +285,11 @@ def test_guide_count_or():
         {'text': 'OR with 4 guides but 5 were requested', 'category': 'caution'}]
 
     # This configuration should warn with too many bright stars
-    # (has > 1.0 stars brighter than 6.1
+    # (has > 1.0 stars brighter than 5.5
     stars = StarsTable.empty()
     stars.add_fake_constellation(n_stars=3, mag=8.0)
-    stars.add_fake_star(yang=1000, zang=1000, mag=6.0)
-    stars.add_fake_star(yang=-1000, zang=1000, mag=6.0)
+    stars.add_fake_star(yang=1000, zang=1000, mag=5.4)
+    stars.add_fake_star(yang=-1000, zang=1000, mag=5.4)
     aca = get_aca_catalog(**mod_std_info(n_fid=3, n_guide=5, obsid=1), stars=stars, dark=DARK40,
                           raise_exc=True)
     aca = ACAReviewTable(aca)
@@ -297,7 +297,7 @@ def test_guide_count_or():
     assert len(aca.messages) == 1
     msg = aca.messages[0]
     assert msg['category'] == 'caution'
-    assert 'OR with more than 1 stars brighter than 6.1.' in msg['text']
+    assert 'OR with more than 1 stars brighter than 5.5.' in msg['text']
 
 
 def test_pos_err_on_guide():


### PR DESCRIPTION
## Description

Update guide bright count check.

1. This fixes a bug where fid/acq/mon were included in the check for a count of stars brighter than 6.1.
2. This moves the bright count mag limit from 6.1 to 5.5 consistent with the star selection move from 5.8 to 5.2.

## Interface impacts

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
- [x] Linux

Independent check of unit tests by @taldcroft :
- [x] Mac

### Functional tests
Unit test updated to match the move of the bright count limit from 6.1 to 5.5.
