### PR TITLE
Silence warning from clipping MAXMAG table

### DIFF
--- a/sparkles/tests/test_find_er_catalog.py
+++ b/sparkles/tests/test_find_er_catalog.py
@@ -121,6 +121,7 @@ def test_find_er_catalog_fails():
     with warnings.catch_warnings():
         # Ignore warning about grid_model clipping t_ccd
         warnings.filterwarnings("ignore", module=r'.*star_probs.*')
+        warnings.filterwarnings("ignore", message=r'.*interpolating MAXMAGs table.*')
         aca = get_aca_catalog(**kwargs)
         acar, att_opts = find_er_catalog(aca, ATTS, alg='input_order')
     assert acar is None


### PR DESCRIPTION
## Description

Add a warning filter to silence new expected warning
```
UserWarning: Clipping t_ccd=10 to 0.0 for interpolating MAXMAGs table
```
for a test that uses t_ccd=+10. 


## Interface impacts
None

## Testing
Tested against proseco master with https://github.com/sot/proseco/pull/376

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
Unit tests run without this change show:
```
ska3-jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.8.12, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /proj/sot/ska/jeanproj/git/sparkles, configfile: pytest.ini
plugins: anyio-2.2.0, hypothesis-6.29.3, arraydiff-0.3, astropy-header-0.1.2, cov-3.0.0, mock-3.6.1, doctestplus-0.11.2, openfiles-0.5.0, filter-subpackage-0.1.1, remotedata-0.3.3
collected 52 items                                                             

sparkles/tests/test_checks.py ............................               [ 53%]
sparkles/tests/test_find_er_catalog.py .....                             [ 63%]
sparkles/tests/test_review.py ................                           [ 94%]
sparkles/tests/test_yoshi.py ...                                         [100%]

=============================== warnings summary ===============================
sparkles/tests/test_find_er_catalog.py::test_find_er_catalog_fails
sparkles/tests/test_find_er_catalog.py::test_find_er_catalog_fails
  /home/jeanconn/git/proseco/proseco/acq.py:70: UserWarning: Clipping t_ccd=10 to 0.0 for interpolating MAXMAGs table
    warnings.warn(f"Clipping {t_ccd=} to 0.0 for interpolating MAXMAGs table")

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================== 52 passed, 2 warnings in 93.61s (0:01:33) ===================
```
Unit tests run with this change show:
```
ska3-jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.8.12, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /proj/sot/ska/jeanproj/git/sparkles, configfile: pytest.ini
plugins: anyio-2.2.0, hypothesis-6.29.3, arraydiff-0.3, astropy-header-0.1.2, cov-3.0.0, mock-3.6.1, doctestplus-0.11.2, openfiles-0.5.0, filter-subpackage-0.1.1, remotedata-0.3.3
collected 52 items                                                             

sparkles/tests/test_checks.py ............................               [ 53%]
sparkles/tests/test_find_er_catalog.py .....                             [ 63%]
sparkles/tests/test_review.py ................                           [ 94%]
sparkles/tests/test_yoshi.py ...                                         [100%]

======================== 52 passed in 96.69s (0:01:36) =========================

```
