### PR TITLE
Check for 4x4 dither for 3.5 to 4.0 guide_count

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1218,10 +1218,10 @@ Predicted Acq CCD temperature (init) : {self.t_ccd_acq:.1f}{t_ccd_eff_acq_msg}""
     # Add a check that for ORs with guide count between 3.5 and 4.0, the
     # dither is 4 arcsec if dynamic background not enabled.
     def check_dither(self):
-        """Check dither
         """
-        # The current dither check is just to confirm that the dither is 4x4 if
-        # dynamic background is not in use and the field has a low guide_count
+        Check dither.  This presently checks that dither is 4x4 arcsec if
+        dynamic background is not in use and the field has a low guide_count.
+        """
 
         # Skip check if guide_count is 4.0 or greater
         if self.guide_count >= 4.0:
@@ -1231,11 +1231,11 @@ Predicted Acq CCD temperature (init) : {self.t_ccd_acq:.1f}{t_ccd_eff_acq_msg}""
         if self.dyn_bgd_n_faint > 0:
             return
 
-        # Check that dither is <= 4x4
+        # Check that dither is <= 4x4 arcsec
         if self.dither_guide.y > 4.0 or self.dither_guide.z > 4.0:
             self.add_message(
                 'critical',
-                f'guide_count {self.guide_count:.2f} and dither > 4x4')
+                f'guide_count {self.guide_count:.2f} and dither > 4x4 arcsec')
 
     def check_pos_err_guide(self, star):
         """Warn on stars with larger POS_ERR (warning at 1" critical at 2")

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -314,6 +314,8 @@ def test_too_many_bright_stars():
 
 
 def test_low_guide_count():
+    """Test that a 3.5 to 4.0 guide_count observation gets a critical warning
+    on guide_count if man_angle_next > 5 (no creep-away)."""
     # Set a scenario with guide_count in the 3.5 to 4.0 range and confirm a
     # critical warning.
     stars = StarsTable.empty()
@@ -322,6 +324,9 @@ def test_low_guide_count():
                           stars=stars, dark=DARK40,
                           raise_exc=True)
     acar = ACAReviewTable(aca)
+    # Confirm the guide_count is in the range we want for the test to be valid
+    assert acar.guide_count <= 4.0 and acar.guide_count > 3.5
+    assert acar.man_angle_next > 5
     acar.check_guide_count()
     assert acar.messages == [
         {'text': 'OR count of guide stars 3.65 < 4.0', 'category': 'critical'},
@@ -329,6 +334,8 @@ def test_low_guide_count():
 
 
 def test_low_guide_count_creep_away():
+    """Test that a 3.5 to 4.0 guide_count observation does not get a critical warning
+    on guide_count if man_angle_next <= 5 (creep-away)."""
     # Set a scenario with guide_count in the 3.5 to 4.0 range but with
     # a creep away (maneuver angle <= 5), and confirm that is just a warning
     # (not critical).
@@ -338,6 +345,8 @@ def test_low_guide_count_creep_away():
                           stars=stars, dark=DARK40,
                           raise_exc=True)
     acar = ACAReviewTable(aca)
+    # Confirm the guide_count is in the range we want for the test to be valid
+    assert acar.guide_count <= 4.0 and acar.guide_count > 3.5
     acar.check_guide_count()
     assert acar.messages == [
         {'text': 'OR count of guide stars 3.65 < 4.0', 'category': 'warning'},
@@ -345,7 +354,8 @@ def test_low_guide_count_creep_away():
 
 
 def test_reduced_dither_low_guide_count():
-
+    """Test that a 3.5 to 4.0 guide_count observation without dynamic background
+    in use (dyn_bgd_n_faint == 0) does not get a dither critical warning for 4x4 arcsec dither."""
     # Set a scenario with guide_count in the 3.5 to 4.0 range
     # dither == 4x4 to get no warnings
     stars = StarsTable.empty()
@@ -355,11 +365,18 @@ def test_reduced_dither_low_guide_count():
                           stars=stars, dark=DARK40,
                           raise_exc=True)
     acar = ACAReviewTable(aca)
+
+    # Confirm the guide_count is in the range we want for the test to be valid
+    assert acar.guide_count <= 4.0 and acar.guide_count > 3.5
+
+    # Run the dither check
     acar.check_dither()
     assert len(acar.messages) == 0
 
 
 def test_not_reduced_dither_low_guide_count():
+    """Test that a 3.5 to 4.0 guide_count observation without dynamic background
+    in use (dyn_bgd_n_faint == 0) gets a dither critical warning for 8x8 arcsec dither."""
     # Set a scenario with guide_count in the 3.5 to 4.0 range and
     # implicit dyn_bgd_n_faint=0 and dither > 4x4 to get a critical warning
     stars = StarsTable.empty()
@@ -369,12 +386,19 @@ def test_not_reduced_dither_low_guide_count():
                           stars=stars, dark=DARK40,
                           raise_exc=True)
     acar = ACAReviewTable(aca)
+
+    # Confirm the guide_count is in the range we want for the test to be valid
+    assert acar.guide_count <= 4.0 and acar.guide_count > 3.5
+
+    # Run the dither check
     acar.check_dither()
     assert acar.messages == [
-        {'text': 'guide_count 3.65 and dither > 4x4', 'category': 'critical'}]
+        {'text': 'guide_count 3.65 and dither > 4x4 arcsec', 'category': 'critical'}]
 
 
 def test_not_reduced_dither_low_guide_count_dyn_bgd():
+    """Test that a 3.5 to 4.0 guide_count observation with dynamic background
+    in use (dyn_bgd_n_faint > 0) does not get a dither critical warning for 8x8 arcsec dither."""
     # Set a scenario with guide_count in the 3.5 to 4.0 range with dither
     # 8x8 but dynamic background running (inferred from dyn_bgd_n_faint > 0)
     # This has a fainter last star, as dyn_bgd_n_faint=1 changes the guide_count
@@ -386,6 +410,8 @@ def test_not_reduced_dither_low_guide_count_dyn_bgd():
                           stars=stars, dark=DARK40,
                           raise_exc=True)
     acar = ACAReviewTable(aca)
+    # Confirm the guide_count is in the range we want for the test to be valid
+    assert acar.guide_count <= 4.0 and acar.guide_count > 3.5
     acar.check_dither()
     assert len(acar.messages) == 0
 

--- a/sparkles/tests/test_yoshi.py
+++ b/sparkles/tests/test_yoshi.py
@@ -46,7 +46,7 @@ def test_run_one_yoshi():
         "ra_aca": 238.96459762180638,
         "dec_aca": 66.400811774068146,
         "roll_aca": 197.20855489084187,
-        "n_critical": 2,
+        "n_critical": 3,
         "n_warning": 1,
         "n_caution": 0,
         "n_info": 1,


### PR DESCRIPTION
## Description

Add a requirement / check that fields with low guide count (3.5 <= guide_count < 4) also have reduced (4x4) dither unless we're evaluating with dynamic background.  This implementation infers if we are using dynamic background from dyn_bgd_n_faint.  I don't know if that is the best thing or if we should have something separate to control this like an env VAR.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by @taldcroft 
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Unit tests updated to have some that apply to this new check.
