### PR TITLE
Add dyn-bgd-n-faint option for review

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -76,6 +76,7 @@ def main(sys_args=None):
         help="Process only this obsid (can specify multiple times, default=all",
     )
     parser.add_argument("--quiet", action="store_true", help="Run quietly")
+    parser.add_argument("--dyn-bgd-n-faint", type=int, help="Dynamic bgd bonus stars")
     parser.add_argument(
         "--open-html", action="store_true", help="Open HTML in webbrowser"
     )
@@ -163,6 +164,7 @@ def main(sys_args=None):
         obsids=args.obsid,
         open_html=args.open_html,
         roll_args=roll_args,
+        dyn_bgd_n_faint=args.dyn_bgd_n_faint,
     )
 
 
@@ -175,6 +177,7 @@ def run_aca_review(
     report_level="none",
     roll_level="none",
     roll_args=None,
+    dyn_bgd_n_faint=None,
     loud=False,
     obsids=None,
     open_html=False,
@@ -242,6 +245,8 @@ def run_aca_review(
     :param report_level: report level threshold for generating acq and guide report
     :param roll_level: level threshold for suggesting alternate rolls
     :param roll_args: None or dict of arguments for ``get_roll_options``
+    :param dyn_bgd_n_faint: int for dynamic background bonus calculation.  Overrides value
+        in input.
     :param loud: print status information during checking
     :param obsids: list of obsids for selecting a subset for review (mostly for debug)
     :param is_ORs: list of is_OR values (for roll options review page)
@@ -259,6 +264,7 @@ def run_aca_review(
             report_level=report_level,
             roll_level=roll_level,
             roll_args=roll_args,
+            dyn_bgd_n_faint=dyn_bgd_n_faint,
             loud=loud,
             obsids=obsids,
             open_html=open_html,
@@ -283,6 +289,7 @@ def _run_aca_review(
     report_level="none",
     roll_level="none",
     roll_args=None,
+    dyn_bgd_n_faint=None,
     loud=False,
     obsids=None,
     open_html=False,
@@ -326,6 +333,15 @@ def _run_aca_review(
         aca.context.clear()
 
         aca.set_stars_and_mask()  # Not stored in pickle, need manual restoration
+
+        if dyn_bgd_n_faint is not None:
+            if aca.dyn_bgd_n_faint != dyn_bgd_n_faint:
+                aca.add_message(
+                    "info",
+                    text=f"Using dyn_bgd_n_faint={dyn_bgd_n_faint} (call_args val={aca.dyn_bgd_n_faint})",
+                )
+                aca.dyn_bgd_n_faint = dyn_bgd_n_faint
+
         aca.check_catalog()
 
         # Find roll options if requested

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -338,7 +338,8 @@ def _run_aca_review(
             if aca.dyn_bgd_n_faint != dyn_bgd_n_faint:
                 aca.add_message(
                     "info",
-                    text=f"Using dyn_bgd_n_faint={dyn_bgd_n_faint} (call_args val={aca.dyn_bgd_n_faint})",
+                    text=f"Using dyn_bgd_n_faint={dyn_bgd_n_faint} "
+                         f"(call_args val={aca.dyn_bgd_n_faint})",
                 )
                 aca.dyn_bgd_n_faint = dyn_bgd_n_faint
 

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -357,6 +357,40 @@ def test_run_aca_review_function(tmpdir):
     assert "TEST_LOAD sparkles review" in (path / "index.html").read_text()
 
 
+def test_run_aca_review_dyn_bgd_n_faint(tmpdir):
+    aca = get_aca_catalog(**KWARGS_48464)
+    acar = aca.get_review_table()
+    acars = [acar]
+
+    exc = run_aca_review(
+        load_name="test_load",
+        report_dir=tmpdir,
+        acars=acars,
+        dyn_bgd_n_faint=2,
+    )
+
+    assert exc is None
+    assert acar.dyn_bgd_n_faint == 2
+    assert np.isclose(acar.guide_count, 6, atol=0.1)
+
+    # Assert same warnings as test_run_aca_review_function but with a different
+    # guide count and new info message
+    assert acar.messages == [
+        {"text": "Using dyn_bgd_n_faint=2 (call_args val=0)", "category": "info"},
+        {
+            "text": "Guide star imposter offset 2.6, limit 2.5 arcsec",
+            "category": "warning",
+            "idx": 4,
+        },
+        {"text": "P2: 3.33 less than 4.0 for ER", "category": "warning"},
+        {
+            "text": "ER count of 9th (8.9 for -9.9C) mag guide stars 2.16 < 3.0",
+            "category": "critical",
+        },
+        {"text": "ER with 6 guides but 8 were requested", "category": "caution"},
+    ]
+
+
 def test_roll_outside_range():
     """
     Run a test on obsid 48334 from ~MAR1119 that is at a pitch that has 0 roll_dev


### PR DESCRIPTION
## Description

Add dyn-bgd-n-faint option for review

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Lets reviewer use dyn-bgd-n-faint without hacks in core.py

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds an info statement on every observation in the output.

## Testing
"Still needs https://github.com/sot/ska_helpers/pull/32 and https://github.com/sot/ska_sun/pull/27 for current unit tests."

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Javier
- [ ] Mac

Test setup requiring ska_helper and ska_sun was not originally defined here - without those changes for the roll limits, the two test_review tests noted by Javier fail.  This is OK for this PR -Jean.

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Output including obsid 25821 (Abell 2029) at:

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/sparkles-pr189/MAY2923P_2023_139_17_44_50_719_sparkles/#id25821
