### PR TITLE
Fix issue computing t_ccds_bonus and refactor into function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,11 @@ repos:
     rev: 23.3.0
     hooks:
     - id: black
-      language_version: python3.10
+      language_version: "python3.10"
 
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.270
     hooks:
     -   id: ruff
+        language_version: "python3.10"
         args: [--exit-non-zero-on-fix]

--- a/sparkles/__init__.py
+++ b/sparkles/__init__.py
@@ -2,7 +2,7 @@ import ska_helpers
 
 __version__ = ska_helpers.get_version(__package__)
 
-from .core import ACAReviewTable, run_aca_review  # noqa: F401
+from .core import ACAReviewTable, get_t_ccds_bonus, run_aca_review  # noqa: F401
 
 
 def test(*args, **kwargs):

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -363,8 +363,10 @@ def _run_aca_review(
             if aca.dyn_bgd_n_faint != dyn_bgd_n_faint:
                 aca.add_message(
                     "info",
-                    text=f"Using dyn_bgd_n_faint={dyn_bgd_n_faint} "
-                    f"(call_args val={aca.dyn_bgd_n_faint})",
+                    text=(
+                        f"Using dyn_bgd_n_faint={dyn_bgd_n_faint} "
+                        f"(call_args val={aca.dyn_bgd_n_faint})"
+                    ),
                 )
                 aca.dyn_bgd_n_faint = dyn_bgd_n_faint
 

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -13,7 +13,7 @@ from proseco.core import StarsTable
 from proseco.tests.test_common import DARK40, STD_INFO, mod_std_info
 from Quaternion import Quat
 
-from sparkles import ACAReviewTable
+from sparkles import ACAReviewTable, get_t_ccds_bonus
 
 
 def test_check_slice_index():
@@ -464,6 +464,44 @@ def test_reduced_dither_low_guide_count():
     # Run the dither check
     acar.check_dither()
     assert len(acar.messages) == 0
+
+
+def test_get_t_ccds_bonus_1():
+    mags = [1, 10, 2, 11, 3, 4]
+    t_ccd = 10
+
+    # Temps corresponding to two faintest stars are smaller.
+    t_ccds = get_t_ccds_bonus(mags, t_ccd, dyn_bgd_n_faint=2, dyn_bgd_dt_ccd=-1)
+    assert np.all(t_ccds == [10, 9, 10, 9, 10, 10])
+
+    # Temps corresponding to three faintest stars are smaller.
+    t_ccds = get_t_ccds_bonus(mags, t_ccd, dyn_bgd_n_faint=3, dyn_bgd_dt_ccd=-1)
+    assert np.all(t_ccds == [10, 9, 10, 9, 10, 9])
+
+    # Temps corresponding to just the three faintest stars are smaller because of the
+    # minimum number of anchor stars = 3.
+    t_ccds = get_t_ccds_bonus(mags, t_ccd, dyn_bgd_n_faint=4, dyn_bgd_dt_ccd=-1)
+    assert np.all(t_ccds == [10, 9, 10, 9, 10, 9])
+
+    t_ccds = get_t_ccds_bonus(mags, t_ccd, dyn_bgd_n_faint=0, dyn_bgd_dt_ccd=-1)
+    assert np.all(t_ccds == [10, 10, 10, 10, 10, 10])
+
+
+def test_get_t_ccds_bonus_min_anchor():
+    mags = [1, 10, 2]
+    t_ccd = 10
+    t_ccds = get_t_ccds_bonus(mags, t_ccd, dyn_bgd_n_faint=2, dyn_bgd_dt_ccd=-1)
+    assert np.all(t_ccds == [10, 10, 10])
+
+    t_ccds = get_t_ccds_bonus(mags, t_ccd, dyn_bgd_n_faint=4, dyn_bgd_dt_ccd=-1)
+    assert np.all(t_ccds == [10, 10, 10])
+
+
+def test_get_t_ccds_bonus_small_catalog():
+    mags = [1]
+    t_ccd = 10
+    t_ccds = get_t_ccds_bonus(mags, t_ccd, dyn_bgd_n_faint=2, dyn_bgd_dt_ccd=-1)
+    assert np.all(t_ccds == [10])
 
 
 def test_not_reduced_dither_low_guide_count():

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -382,7 +382,7 @@ def test_run_aca_review_dyn_bgd_n_faint(tmpdir):
         },
         {"text": "P2: 3.33 less than 4.0 for ER", "category": "warning"},
         {
-            "text": "ER count of 9th (8.9 for -9.9C) mag guide stars 2.16 < 3.0",
+            "text": "ER count of 9th (8.9 for -9.9C) mag guide stars 1.91 < 3.0",
             "category": "critical",
         },
         {"text": "ER with 6 guides but 8 were requested", "category": "caution"},


### PR DESCRIPTION
## Description

The previous implementation had a bug where the `t_ccds_bonus` property was ordered with respect to `sorted(mags)` instead of `mags`. In most cases the guide star mags are roughly sorted in ascending order, but this is not always the case.

An unrelated update was applied to the pre-commit config to get that working.

This also includes the formatting fix in #191.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

Adds a new function `get_t_ccds_bonus` to the top-level public interface. This can be used in starcheck.

## Testing
<!-- If relevant describe any special setup for testing. -->

Added new unit tests that give better coverage of this functionality.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by Jean
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Unit tests added as functional tests.
