### PR TITLE
With dyn_bgd_n_faint option, override it in the GuideTable too

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -369,6 +369,7 @@ def _run_aca_review(
                     ),
                 )
                 aca.dyn_bgd_n_faint = dyn_bgd_n_faint
+                aca.guides.dyn_bgd_n_faint = dyn_bgd_n_faint
 
         aca.check_catalog()
 


### PR DESCRIPTION
## Description

Pass the dyn-bgd-n-faint option value through to the GuideTable.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes issue seen in JUL0323A on obsid 25274 that when using sparkles with the --dyn-bgd-n-faint 2 override, acceptable candidates with that option were marked with CRITICAL warnings because the override was not available for the checking of the guide stars.

The override really shouldn't be needed going forward, but I think it should just get in now so if we move to dyn-bgd-n-faint=3 or need to override a value in a pickle file it will be applied correctly.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
I tested on Linux with /proj/sot/ska3/test set to 2023.3rc9 . 

<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

Functional test outputs at https://icxc.cfa.harvard.edu/aspect/test_review_outputs/sparkles-pr193/ .

I ran

```
sparkles /data/mpcrit1/mplogs/2023/JUL0323/oflsa/output/JUL0323A_proseco.pkl.gz --dyn-bgd-n-faint 2 --report-dir flight
export PYTHONPATH=/home/jeanconn/git/sparkles # set to more-dyn branch
python -m sparkles /data/mpcrit1/mplogs/2023/JUL0323/oflsa/output/JUL0323A_proseco.pkl.gz --dyn-bgd-n-faint 2 --report-dir test
```
The "flight" outputs at https://icxc.cfa.harvard.edu/aspect/test_review_outputs/sparkles-pr193/flight/ show the critical warnings on 25274 and 27940 because the dyn_bgd_n_faint value of 2 was not used in the guide checking.

The "test" outputs at https://icxc.cfa.harvard.edu/aspect/test_review_outputs/sparkles-pr193/test/ show no critical warnings on those obsids (correctly).

Those are the only diffs.

