### PR TITLE
Pin chandra_models version to 3.48 for tests

### DIFF
--- a/sparkles/tests/conftest.py
+++ b/sparkles/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def use_fixed_chandra_models(monkeypatch):
+    monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")


### PR DESCRIPTION
## Description
Pin chandra_models version to 3.48 for tests

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
I checked out chandra_models at 3.49, set CHANDRA_MODELS_REPO_DIR to /Users/jean/git/chandra_models, set CHANDRA_MODELS_DEFAULT_VERSION to pitch-roll-constraint-2023_020, and confirmed test failures without this PR.

<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by @taldcroft:
- [x] Mac: testing in the manner of @jeanconn described above
- [x] Mac: `chandra_models` repo checked out at 3.49 and `CHANDRA_MODELS_DEFAULT_VERSION` unset.

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Unit testing is functional testing for this change.
