### PR TITLE
Update to use more test fixtures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
     - id: black
       language_version: "python3.10"
 
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.270
+    rev: v0.0.280
     hooks:
     -   id: ruff
         language_version: "python3.10"

--- a/sparkles/tests/conftest.py
+++ b/sparkles/tests/conftest.py
@@ -1,5 +1,5 @@
-import pytest
 import agasc
+import pytest
 
 
 @pytest.fixture(autouse=True)

--- a/sparkles/tests/conftest.py
+++ b/sparkles/tests/conftest.py
@@ -1,6 +1,12 @@
 import pytest
+import agasc
 
 
 @pytest.fixture(autouse=True)
 def use_fixed_chandra_models(monkeypatch):
     monkeypatch.setenv("CHANDRA_MODELS_DEFAULT_VERSION", "3.48")
+
+
+@pytest.fixture(autouse=True)
+def do_not_use_agasc_supplement(monkeypatch):
+    monkeypatch.setenv(agasc.SUPPLEMENT_ENABLED_ENV, "False")

--- a/sparkles/tests/test_find_er_catalog.py
+++ b/sparkles/tests/test_find_er_catalog.py
@@ -1,19 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import warnings
-import pytest
 
 import numpy as np
+import pytest
 import Ska.Sun
 from proseco import get_aca_catalog
 from proseco.tests.test_common import mod_std_info
 from Quaternion import Quat
 
-from sparkles.find_er_catalog import (
-    filter_candidate_stars_on_ccd,
-    find_er_catalog,
-    get_candidate_stars,
-    get_guide_counts,
-)
+from sparkles.find_er_catalog import (filter_candidate_stars_on_ccd,
+                                      find_er_catalog, get_candidate_stars,
+                                      get_guide_counts)
 
 
 # Known tough field: PKS 0023-26 pointing

--- a/sparkles/tests/test_find_er_catalog.py
+++ b/sparkles/tests/test_find_er_catalog.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 import warnings
+import pytest
 
 import agasc
 import numpy as np
@@ -16,31 +17,55 @@ from sparkles.find_er_catalog import (
     get_guide_counts,
 )
 
+
 # Known tough field: PKS 0023-26 pointing
-ATT = Quat([0.20668099834, 0.23164729391, 0.002658888173, 0.9505868852])
-DATE = "2021-09-13"
-T_CCD = -8.0
+@pytest.fixture
+def ATT():
+    return Quat([0.20668099834, 0.23164729391, 0.002658888173, 0.9505868852])
+
+
+@pytest.fixture
+def DATE():
+    return "2021-09-13"
+
+
+@pytest.fixture
+def T_CCD():
+    return -8.0
+
 
 # Get initial catalog at the PKS 0023-26 attitude. Ignore the penalty limit for
 # this work.
-KWARGS = mod_std_info(
-    att=ATT,
-    t_ccd=T_CCD,
-    date=DATE,
-    n_guide=8,
-    n_fid=0,
-    obsid=99999,
-    t_ccd_penalty_limit=999,
-)
-ACA = get_aca_catalog(**KWARGS)
-DPITCHES, DYAWS = np.ogrid[-0.01:-3.5:4j, -3.1:3:3j]
-SUN_RA, SUN_DEC = Ska.Sun.position(ACA.date)
-ATTS = Ska.Sun.apply_sun_pitch_yaw(
-    ACA.att, pitch=DPITCHES, yaw=DYAWS, sun_ra=SUN_RA, sun_dec=SUN_DEC
-)
 
 
-def test_get_candidate_and_filter_stars():
+@pytest.fixture
+def KWARGS(ATT, T_CCD, DATE):
+    return mod_std_info(
+        att=ATT,
+        t_ccd=T_CCD,
+        date=DATE,
+        n_guide=8,
+        n_fid=0,
+        obsid=99999,
+        t_ccd_penalty_limit=999,
+    )
+
+
+@pytest.fixture
+def ACA(KWARGS):
+    return get_aca_catalog(**KWARGS)
+
+
+@pytest.fixture
+def ATTS(ACA):
+    DPITCHES, DYAWS = np.ogrid[-0.01:-3.5:4j, -3.1:3:3j]
+    SUN_RA, SUN_DEC = Ska.Sun.position(ACA.date)
+    return Ska.Sun.apply_sun_pitch_yaw(
+        ACA.att, pitch=DPITCHES, yaw=DYAWS, sun_ra=SUN_RA, sun_dec=SUN_DEC
+    )
+
+
+def test_get_candidate_and_filter_stars(ATT, T_CCD, DATE):
     stars = get_candidate_stars(ATT, T_CCD, date=DATE)
     stars = filter_candidate_stars_on_ccd(ATT, stars)
 
@@ -64,7 +89,7 @@ TEST_COLS = [
 ]
 
 
-def test_find_er_catalog_minus_2_pitch_bins():
+def test_find_er_catalog_minus_2_pitch_bins(ACA, ATTS):
     # Try it all for the bad field near PKS 0023-26
     acar, att_opts = find_er_catalog(ACA, ATTS, alg="pitch_bins")
     # import pprint; pprint.pprint(att_opts[TEST_COLS].pformat_all(), width=100)
@@ -129,7 +154,7 @@ def test_find_er_catalog_minus_2_pitch_bins():
     ]
 
 
-def test_find_er_catalog_minus_2_count_all():
+def test_find_er_catalog_minus_2_count_all(ACA, ATTS):
     acar, att_opts = find_er_catalog(ACA, ATTS, alg="count_all")
     # import pprint; pprint.pprint(att_opts[TEST_COLS].pformat_all(), width=100)
     assert acar is att_opts["acar"][8]
@@ -193,7 +218,7 @@ def test_find_er_catalog_minus_2_count_all():
     ]
 
 
-def test_find_er_catalog_minus_2_input_order():
+def test_find_er_catalog_minus_2_input_order(ACA, ATTS):
     acar, att_opts = find_er_catalog(ACA, ATTS, alg="input_order")
     # import pprint; pprint.pprint(att_opts[TEST_COLS].pformat_all(), width=100)
     assert acar is att_opts["acar"][8]
@@ -257,7 +282,7 @@ def test_find_er_catalog_minus_2_input_order():
     ]
 
 
-def test_find_er_catalog_fails():
+def test_find_er_catalog_fails(ATT, DATE, ATTS):
     """Test a catalog that will certainly fail at +10 degC"""
     kwargs = mod_std_info(
         att=ATT,

--- a/sparkles/tests/test_find_er_catalog.py
+++ b/sparkles/tests/test_find_er_catalog.py
@@ -9,10 +9,6 @@ from proseco import get_aca_catalog
 from proseco.tests.test_common import mod_std_info
 from Quaternion import Quat
 
-# Do not use the AGASC supplement in testing since mags can change
-os.environ[agasc.SUPPLEMENT_ENABLED_ENV] = "False"
-
-
 from sparkles.find_er_catalog import (
     filter_candidate_stars_on_ccd,
     find_er_catalog,

--- a/sparkles/tests/test_find_er_catalog.py
+++ b/sparkles/tests/test_find_er_catalog.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import os
 import warnings
 import pytest
 
-import agasc
 import numpy as np
 import Ska.Sun
 from proseco import get_aca_catalog

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -14,7 +14,6 @@ from ska_sun import apply_sun_pitch_yaw, nominal_roll
 
 from sparkles import ACAReviewTable, run_aca_review
 
-
 KWARGS_48464 = {
     "att": [-0.51759295, -0.30129397, 0.27093045, 0.75360213],
     "date": "2019:031:13:25:30.000",

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -1,9 +1,7 @@
 import gzip
-import os
 import pickle
 from pathlib import Path
 
-import agasc
 import numpy as np
 import pytest
 import ska_sun

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -16,8 +16,6 @@ from ska_sun import apply_sun_pitch_yaw, nominal_roll
 
 from sparkles import ACAReviewTable, run_aca_review
 
-# Do not use the AGASC supplement in testing by default since mags can change
-os.environ[agasc.SUPPLEMENT_ENABLED_ENV] = "False"
 
 KWARGS_48464 = {
     "att": [-0.51759295, -0.30129397, 0.27093045, 0.75360213],

--- a/sparkles/tests/test_yoshi.py
+++ b/sparkles/tests/test_yoshi.py
@@ -12,12 +12,6 @@ from sparkles.yoshi import (
 )
 
 
-@pytest.fixture(autouse=True)
-def do_not_use_agasc_supplement(monkeypatch):
-    """Do not use AGASC supplement in any test"""
-    monkeypatch.setenv(agasc.SUPPLEMENT_ENABLED_ENV, "False")
-
-
 @pytest.mark.skipif(not HAS_WEB_SERVICES, reason="No web services available")
 def test_run_one_yoshi():
     """Regression test a single run for a real obsid"""


### PR DESCRIPTION
## Description
Update to use more test fixtures.  This moves the agasc supplement disable to conftest.py and makes the shared data in test_find_er_catalog use fixtures that also respect the CHANDRA_MODELS_DEFAULT_VERSION pinned in conftest.py.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This finishes #190 .  Without the changes to test_find_er_catalog, the ska_testr sparkles test will continue to include a UserWarning that is difficult to filter that the acquisition model is correctly clipped out of the temperature range.

```
============================================================ warnings summary ============================================================
../../../../ska3/test/lib/python3.10/site-packages/chandra_aca/star_probs.py:390
  /proj/sot/ska3/test/lib/python3.10/site-packages/chandra_aca/star_probs.py:390: UserWarning: 
  Model grid-local-quadratic-2023-05.fits.gz computed between 5.0 <= mag <= 10.75, clipping input mag(s) outside that range.
    warnings.warn(
```


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
