### PR TITLE
Do not use aca_t_ccd_penalty_limit via import

### DIFF
--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -47,9 +47,13 @@ def test_t_ccd_effective_message():
     text = acar.get_text_pre()
 
     eff_guide = (
-        kwargs["t_ccd_guide"] + 1 + (kwargs["t_ccd_guide"] - ACA.aca_t_ccd_penalty_limit)
+        kwargs["t_ccd_guide"]
+        + 1
+        + (kwargs["t_ccd_guide"] - ACA.aca_t_ccd_penalty_limit)
     )
-    eff_acq = kwargs["t_ccd_acq"] + 1 + (kwargs["t_ccd_acq"] - ACA.aca_t_ccd_penalty_limit)
+    eff_acq = (
+        kwargs["t_ccd_acq"] + 1 + (kwargs["t_ccd_acq"] - ACA.aca_t_ccd_penalty_limit)
+    )
     assert (
         f'Predicted Guide CCD temperature (max): {kwargs["t_ccd_guide"]:.1f} '
         f'<span class="caution">(Effective : {eff_guide:.1f})</span>' in text

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -3,11 +3,11 @@ import pickle
 from pathlib import Path
 
 import numpy as np
+import proseco.characteristics as ACA
 import pytest
 import ska_sun
 from proseco import get_aca_catalog
 from proseco.characteristics import MonCoord, MonFunc
-import proseco.characteristics as ACA
 from proseco.core import StarsTable
 from proseco.tests.test_common import DARK40, mod_std_info
 from Quaternion import Quat

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -6,7 +6,8 @@ import numpy as np
 import pytest
 import ska_sun
 from proseco import get_aca_catalog
-from proseco.characteristics import MonCoord, MonFunc, aca_t_ccd_penalty_limit
+from proseco.characteristics import MonCoord, MonFunc
+import proseco.characteristics as ACA
 from proseco.core import StarsTable
 from proseco.tests.test_common import DARK40, mod_std_info
 from Quaternion import Quat
@@ -36,8 +37,8 @@ def test_t_ccd_effective_message():
     """Test printing a message about effective guide and/or acq CCD temperature
     when it is different from the predicted temperature."""
     kwargs = KWARGS_48464.copy()
-    kwargs["t_ccd_guide"] = aca_t_ccd_penalty_limit + 0.75
-    kwargs["t_ccd_acq"] = aca_t_ccd_penalty_limit + 0.5
+    kwargs["t_ccd_guide"] = ACA.aca_t_ccd_penalty_limit + 0.75
+    kwargs["t_ccd_acq"] = ACA.aca_t_ccd_penalty_limit + 0.5
     aca = get_aca_catalog(**kwargs)
     acar = aca.get_review_table()
     acar.run_aca_review()
@@ -46,9 +47,9 @@ def test_t_ccd_effective_message():
     text = acar.get_text_pre()
 
     eff_guide = (
-        kwargs["t_ccd_guide"] + 1 + (kwargs["t_ccd_guide"] - aca_t_ccd_penalty_limit)
+        kwargs["t_ccd_guide"] + 1 + (kwargs["t_ccd_guide"] - ACA.aca_t_ccd_penalty_limit)
     )
-    eff_acq = kwargs["t_ccd_acq"] + 1 + (kwargs["t_ccd_acq"] - aca_t_ccd_penalty_limit)
+    eff_acq = kwargs["t_ccd_acq"] + 1 + (kwargs["t_ccd_acq"] - ACA.aca_t_ccd_penalty_limit)
     assert (
         f'Predicted Guide CCD temperature (max): {kwargs["t_ccd_guide"]:.1f} '
         f'<span class="caution">(Effective : {eff_guide:.1f})</span>' in text


### PR DESCRIPTION
## Description

Do not use aca_t_ccd_penalty_limit via import .  If we only _use_ the penalty limit attribute directly within the test function it will have a value that corresponds to CHANDRA_MODELS_DEFAULT_VERSION=3.48 from the conftest.py .

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes test against proseco with https://github.com/sot/proseco/pull/386 .

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
Tested out of a ska3-masters environment on fido that included proseco up through https://github.com/sot/proseco/pull/386 .
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by Javier


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
