### PR TITLE
Update tests for AGASC >= 1.8 and lazy import matplotlib

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -13,11 +13,7 @@ import traceback
 from itertools import chain, combinations
 from pathlib import Path
 
-import matplotlib
-
-matplotlib.use("Agg")
 import chandra_aca
-import matplotlib.pyplot as plt
 import numpy as np
 import proseco
 import proseco.characteristics as ACA
@@ -25,7 +21,6 @@ from astropy.table import Column, Table
 from chandra_aca.star_probs import guide_count
 from chandra_aca.transform import mag_to_count_rate, snr_mag_for_t_ccd, yagzag_to_pixels
 from jinja2 import Template
-from matplotlib.patches import Circle
 from proseco.catalog import ACATable
 from proseco.core import MetaAttribute
 
@@ -990,6 +985,8 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
         :param ax: matplotlib axes object for plotting to (optional)
         :param kwargs: other keyword args for plot_stars
         """
+        from matplotlib.patches import Circle
+
         fig = super().plot(ax, **kwargs)
         if ax is None:
             ax = fig.gca()
@@ -1036,6 +1033,11 @@ class ACAReviewTable(ACATable, RollOptimizeMixin):
 
     def make_starcat_plot(self):
         """Make star catalog plot for this observation."""
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
         plotname = f"starcat{self.report_id}.png"
         outfile = self.obsid_dir / plotname
         self.context["catalog_plot"] = outfile.relative_to(self.preview_dir).as_posix()

--- a/sparkles/tests/conftest.py
+++ b/sparkles/tests/conftest.py
@@ -10,3 +10,16 @@ def use_fixed_chandra_models(monkeypatch):
 @pytest.fixture(autouse=True)
 def do_not_use_agasc_supplement(monkeypatch):
     monkeypatch.setenv(agasc.SUPPLEMENT_ENABLED_ENV, "False")
+
+
+# By default test with the latest AGASC version available including release candidates
+@pytest.fixture(autouse=True)
+def proseco_agasc_rc(monkeypatch):
+    agasc_file = agasc.get_agasc_filename("proseco_agasc_*", allow_rc=True)
+    monkeypatch.setenv("AGASC_HDF5_FILE", agasc_file)
+
+
+@pytest.fixture()
+def proseco_agasc_1p7(monkeypatch):
+    agasc_file = agasc.get_agasc_filename("proseco_agasc_*", version="1p7")
+    monkeypatch.setenv("AGASC_HDF5_FILE", agasc_file)

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -6,7 +6,9 @@ import pickle
 import agasc
 import numpy as np
 import pytest
+import tables
 from chandra_aca.transform import mag_to_count_rate
+from packaging.version import Version
 from proseco import get_aca_catalog
 from proseco.characteristics import CCD, MonCoord, MonFunc
 from proseco.core import StarsTable
@@ -705,7 +707,8 @@ def test_imposters_on_guide(exp_warn):
         assert len(acar.messages) == 0
 
 
-def test_bad_star_set():
+def test_bad_star_set(proseco_agasc_1p7):
+    # This faint star is no longer in proseco_agasc >= 1.8 so we use 1.7
     bad_id = 1248994952
     star = agasc.get_star(bad_id)
     ra = star["RA"]
@@ -963,3 +966,12 @@ def test_copy_deepcopy_pickle():
             val2 = func(val)
             assert repr(val) == repr(val2)
             assert val is not val2
+
+
+def test_agasc_1p8_or_later():
+    """Check that AGASC 1.8 or later (including RC's) is being used."""
+    agasc_file = agasc.get_agasc_filename()
+    with tables.open_file(agasc_file) as h5:
+        version = Version(h5.root.data.attrs["version"].replace("p", "."))
+    assert version.major == 1
+    assert version.minor >= 8

--- a/sparkles/tests/test_find_er_catalog.py
+++ b/sparkles/tests/test_find_er_catalog.py
@@ -63,7 +63,7 @@ def ATTS(ACA):
     )
 
 
-def test_get_candidate_and_filter_stars(ATT, T_CCD, DATE):
+def test_get_candidate_and_filter_stars(proseco_agasc_1p7, ATT, T_CCD, DATE):
     stars = get_candidate_stars(ATT, T_CCD, date=DATE)
     stars = filter_candidate_stars_on_ccd(ATT, stars)
 
@@ -87,7 +87,7 @@ TEST_COLS = [
 ]
 
 
-def test_find_er_catalog_minus_2_pitch_bins(ACA, ATTS):
+def test_find_er_catalog_minus_2_pitch_bins(proseco_agasc_1p7, ACA, ATTS):
     # Try it all for the bad field near PKS 0023-26
     acar, att_opts = find_er_catalog(ACA, ATTS, alg="pitch_bins")
     # import pprint; pprint.pprint(att_opts[TEST_COLS].pformat_all(), width=100)
@@ -152,7 +152,7 @@ def test_find_er_catalog_minus_2_pitch_bins(ACA, ATTS):
     ]
 
 
-def test_find_er_catalog_minus_2_count_all(ACA, ATTS):
+def test_find_er_catalog_minus_2_count_all(proseco_agasc_1p7, ACA, ATTS):
     acar, att_opts = find_er_catalog(ACA, ATTS, alg="count_all")
     # import pprint; pprint.pprint(att_opts[TEST_COLS].pformat_all(), width=100)
     assert acar is att_opts["acar"][8]
@@ -216,7 +216,7 @@ def test_find_er_catalog_minus_2_count_all(ACA, ATTS):
     ]
 
 
-def test_find_er_catalog_minus_2_input_order(ACA, ATTS):
+def test_find_er_catalog_minus_2_input_order(proseco_agasc_1p7, ACA, ATTS):
     acar, att_opts = find_er_catalog(ACA, ATTS, alg="input_order")
     # import pprint; pprint.pprint(att_opts[TEST_COLS].pformat_all(), width=100)
     assert acar is att_opts["acar"][8]

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -64,7 +64,7 @@ def test_t_ccd_effective_message():
     )
 
 
-def test_review_catalog(tmpdir):
+def test_review_catalog(proseco_agasc_1p7, tmpdir):
     aca = get_aca_catalog(**KWARGS_48464)
     acar = aca.get_review_table()
     acar.run_aca_review()
@@ -261,7 +261,7 @@ def test_roll_options_with_monitor_star():
     acar.get_roll_options()
 
 
-def test_uniform_roll_options():
+def test_uniform_roll_options(proseco_agasc_1p7):
     """Use obsid 22508 as a test case for failing to find a roll option using
     the 'uniq_ids' algorithm and falling through to a 'uniform' search.
 
@@ -326,7 +326,7 @@ def test_catch_exception_from_method():
         acar.run_aca_review(roll_level="BAD VALUE")
 
 
-def test_run_aca_review_function(tmpdir):
+def test_run_aca_review_function(proseco_agasc_1p7, tmpdir):
     aca = get_aca_catalog(**KWARGS_48464)
     acar = aca.get_review_table()
     acars = [acar]
@@ -355,7 +355,7 @@ def test_run_aca_review_function(tmpdir):
     assert "TEST_LOAD sparkles review" in (path / "index.html").read_text()
 
 
-def test_run_aca_review_dyn_bgd_n_faint(tmpdir):
+def test_run_aca_review_dyn_bgd_n_faint(proseco_agasc_1p7, tmpdir):
     aca = get_aca_catalog(**KWARGS_48464)
     acar = aca.get_review_table()
     acars = [acar]
@@ -421,7 +421,7 @@ def test_roll_outside_range():
     assert Quat(kw["att"]).roll >= acar.roll_info["roll_min"]
 
 
-def test_roll_options_dec89_9():
+def test_roll_options_dec89_9(proseco_agasc_1p7):
     """Test getting roll options for an OR and ER at very high declination
     where the difference between the ACA and target frames is large.  Here
     the roll will differ by around 10 deg.
@@ -492,7 +492,7 @@ def test_calc_targ_from_aca():
     assert np.isclose(acar.att.dq(q_targ).yaw * 3600, 69.59, atol=0.01, rtol=0)
 
 
-def test_get_roll_intervals():
+def test_get_roll_intervals(proseco_agasc_1p7):
     """
     Test that the behavior of get_roll_intervals is different for ORs and ERs with
     regard to use of offsets.  They are set to arbitrary large values in the test.

--- a/sparkles/tests/test_yoshi.py
+++ b/sparkles/tests/test_yoshi.py
@@ -1,4 +1,3 @@
-import agasc
 import numpy as np
 import pytest
 from mica.archive.tests.test_cda import HAS_WEB_SERVICES
@@ -148,10 +147,8 @@ def test_get_params_use_cycle():
 
 
 @pytest.mark.skipif(not HAS_WEB_SERVICES, reason="No web services available")
-def test_acar_from_ocat(proseco_agasc_1p7, monkeypatch):
+def test_acar_from_ocat(proseco_agasc_1p7):
     """Get an AcaReviewTable with minimal information filling in rest from OCAT"""
-    monkeypatch.setenv(agasc.SUPPLEMENT_ENABLED_ENV, "False")
-
     acar = ACAReviewTable.from_ocat(
         obsid=8008, date="2022:001", t_ccd=-10, n_acq=6, target_name="Target name"
     )

--- a/sparkles/tests/test_yoshi.py
+++ b/sparkles/tests/test_yoshi.py
@@ -13,7 +13,7 @@ from sparkles.yoshi import (
 
 
 @pytest.mark.skipif(not HAS_WEB_SERVICES, reason="No web services available")
-def test_run_one_yoshi():
+def test_run_one_yoshi(proseco_agasc_1p7):
     """Regression test a single run for a real obsid"""
     request = {
         "obsid": 20562,
@@ -148,7 +148,7 @@ def test_get_params_use_cycle():
 
 
 @pytest.mark.skipif(not HAS_WEB_SERVICES, reason="No web services available")
-def test_acar_from_ocat(monkeypatch):
+def test_acar_from_ocat(proseco_agasc_1p7, monkeypatch):
     """Get an AcaReviewTable with minimal information filling in rest from OCAT"""
     monkeypatch.setenv(agasc.SUPPLEMENT_ENABLED_ENV, "False")
 


### PR DESCRIPTION
## Description

This updates the unit tests to use AGASC >= 1.8 (including release candidates) by default. A number of tests are regression tests that require version 1.7 to obtain the exact same outputs, so those are fixed at 1.7.

In addition a change was made to import matplotlib only when needed for plotting. Sparkles is commonly used only to evaluate the catalog without making a report, so in that case this change saves around 20 Mb of memory and improves performance somewhat.

### Requires

- https://github.com/sot/agasc/pull/155
- https://github.com/sot/proseco/pull/387

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
Using a ska3 dev environment with the required development packages installed and `proseco_agasc_1p8rc4.h5` in `$SKA/data/agasc`:
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Ran `sparkles https://occweb...MAY1523A_proseco.pkl.gz --open-html` and got the expected result.
