### PR TITLE
Add too-cold check for fid lights at acquisition

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1358,19 +1358,21 @@ Predicted Acq CCD temperature (init) : {self.t_ccd_acq:.1f}{t_ccd_eff_acq_msg}""
         Check that the fid lights are in the current search boxes by a check on t_ccd_acq.
         These tolerances apply to observations after the 2022:294 safe mode.
         """
-        if not self.is_ER and CxoTime(self.date).date > "2022:294":
-            if self.fids.t_ccd_acq <= -14.0:
-                self.add_message(
-                    "critical",
-                    f"Fid lights outside boxes (t_ccd_acq {self.fids.t_ccd_acq:.1f} <= -14.0)",
-                )
-                return
-            if self.fids.t_ccd_acq <= -13.5:
-                self.add_message(
-                    "caution",
-                    f"Fid lights near box edge (t_ccd_acq {self.fids.t_ccd_acq:.1f} <= -13.5)",
-                )
-                return
+        if self.is_ER or CxoTime(self.date).date < "2022:294":
+            return
+
+        t_ccd_acq = self.fids.t_ccd_acq
+
+        if t_ccd_acq <= -14.0:
+            self.add_message(
+                "critical",
+                f"Fid lights outside boxes (t_ccd_acq {t_ccd_acq:.1f} <= -14.0)",
+            )
+        elif t_ccd_acq <= -13.5:
+            self.add_message(
+                "caution",
+                f"Fid lights near box edge (t_ccd_acq {t_ccd_acq:.1f} <= -13.5)",
+            )
 
     def check_guide_count(self):
         """

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -80,6 +80,66 @@ def test_n_guide_check_not_enough_stars():
     ]
 
 
+def test_or_too_cold():
+    """Test the check that OR is not too cold"""
+
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(n_stars=5, mag=8.5)
+    aca = get_aca_catalog(
+        **mod_std_info(n_fid=3, n_guide=5, obsid=5000, t_ccd_acq=-5, date="2023:001"),
+        stars=stars,
+        dark=DARK40,
+        raise_exc=True
+    )
+    acar = ACAReviewTable(aca)
+    acar.check_t_ccd_acq()
+    assert acar.messages == []
+
+    aca = get_aca_catalog(
+        **mod_std_info(n_fid=3, n_guide=5, obsid=5000, t_ccd_acq=-19, date="2019:001"),
+        stars=stars,
+        dark=DARK40,
+        raise_exc=True
+    )
+    acar = ACAReviewTable(aca)
+    acar.check_t_ccd_acq()
+    assert acar.messages == []
+
+    aca = get_aca_catalog(
+        **mod_std_info(
+            n_fid=3, n_guide=5, obsid=5000, t_ccd_acq=-13.6, date="2023:001"
+        ),
+        stars=stars,
+        dark=DARK40,
+        raise_exc=True
+    )
+    acar = ACAReviewTable(aca)
+    acar.check_t_ccd_acq()
+    assert acar.messages == [
+        {
+            "text": "Fid lights near box edge (t_ccd_acq -13.6 <= -13.5)",
+            "category": "caution",
+        }
+    ]
+
+    aca = get_aca_catalog(
+        **mod_std_info(
+            n_fid=3, n_guide=5, obsid=5000, t_ccd_acq=-14.1, date="2023:001"
+        ),
+        stars=stars,
+        dark=DARK40,
+        raise_exc=True
+    )
+    acar = ACAReviewTable(aca)
+    acar.check_t_ccd_acq()
+    assert acar.messages == [
+        {
+            "text": "Fid lights outside boxes (t_ccd_acq -14.1 <= -14.0)",
+            "category": "critical",
+        }
+    ]
+
+
 def test_guide_is_candidate():
     """Test the check that guide star meets candidate star requirements
 


### PR DESCRIPTION
## Description

Add a caution warning for acquisition temperature between -13.5 and -14, and a critical for acquisition temperature < -14C.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [X] OSX

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Adds new unit test.
