### PR TITLE
Leave `maxmags` column in ACA Review Table

### DIFF
--- a/sparkles/aca_check_table.py
+++ b/sparkles/aca_check_table.py
@@ -93,10 +93,6 @@ class ACACheckTable(ACATable):
             )
             self.add_column(mag_errs, index=self.colnames.index("mag") + 1)
 
-        # Don't want maxmag column
-        if "maxmag" in self.colnames:
-            del self["maxmag"]
-
         # Customizations for ACAReviewTable.  Don't really need 2 decimals on these.
         for name in ("yang", "zang", "row", "col"):
             self._default_formats[name] = ".1f"


### PR DESCRIPTION
## Description

For some forgotten reason, during initial development I decided to cut out the `maxmags` column from the `ACAReviewTable`. This is an important part of the catalog for any comprehensive review (razl), so this PR puts that column back in the table. More precisely it removes the code that deletes that column from the proseco table.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
The ACA review table will have an extra column. Any tests that depend on the exact repr of such a table may need to be updated but the sparkles tests themselves did not need modification.

In theory this might impact MATLAB tools. One option is to leave the `maxmags` column in `ACACheckTable` and take it back out in `ACAReviewTable`. In fact that was my first implementation, but if it doesn't actually break anything I'd rather go with the current version.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) ➜  sparkles git:(dont-remove-maxmags-column) git rev-parse HEAD                                           
e1a9d66e178e8b74cbd60b8486033c854d8dd193
(ska3) ➜  sparkles git:(dont-remove-maxmags-column) pytest
====================================================== test session starts ======================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 103 items                                                                                                             

sparkles/tests/test_checks.py ............................................................................                [ 73%]
sparkles/tests/test_find_er_catalog.py .....                                                                              [ 78%]
sparkles/tests/test_review.py ..................                                                                          [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                         [100%]

===================================================== 103 passed in 33.82s ======================================================
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
[FEB0724A ouput.](https://icxc.cfa.harvard.edu/aspect/test_review_outputs/sparkles-pr204/FEB0724A_sparkles/)
