### PR TITLE
Refactor ruff into a base and package-specific

### DIFF
--- a/ruff-base.toml
+++ b/ruff-base.toml
@@ -1,4 +1,4 @@
-# Copied originally from pandas
+# Copied originally from pandas. This config requires ruff >= 0.2.
 target-version = "py310"
 
 # fix = true
@@ -27,7 +27,7 @@ lint.select = [
 lint.extend-select = [
 "UP009",  # UTF-8 encoding declaration is unnecessary
 "SIM118",  # Use `key in dict` instead of `key in dict.keys()`
-# "D205",  # One blank line required between summary line and description
+"D205",  # One blank line required between summary line and description
 "ARG001",  # Unused function argument
 "RSE102",  # Unnecessary parentheses on raised exception
 "PERF401",  # Use a list comprehension to create a transformed list
@@ -35,21 +35,14 @@ lint.extend-select = [
 
 lint.ignore = [
   "ISC001", # Disable this for compatibility with ruff format
-  "B028", # No explicit `stacklevel` keyword argument found
-  "B905", # `zip()` without an explicit `strict=` parameter
   "E402", # module level import not at top of file
   "E731", # do not assign a lambda expression, use a def
-  "PLC1901", # compare-to-empty-string
-  "PLR0911", # Too many returns
-  "PLR0912", # Too many branches
-  "PLR0913", # Too many arguments to function call
-  "PLR0915", # Too many statements
   "PLR2004", # Magic number
+  "B028", # No explicit `stacklevel` keyword argument found
 ]
 
 extend-exclude = [
   "docs",
-  "roll_play.py",
 ]
 
 [lint.pycodestyle]

--- a/ruff-base.toml
+++ b/ruff-base.toml
@@ -1,0 +1,64 @@
+# Copied originally from pandas
+target-version = "py310"
+
+# fix = true
+lint.unfixable = []
+
+lint.select = [
+  "I", # isort
+  "F", # pyflakes
+  "E", "W", # pycodestyle
+  "YTT", # flake8-2020
+  "B", # flake8-bugbear
+  "Q", # flake8-quotes
+  "T10", # flake8-debugger
+  "INT", # flake8-gettext
+  "PLC", "PLE", "PLR", "PLW", # pylint
+  "PIE", # misc lints
+  "PYI", # flake8-pyi
+  "TID", # tidy imports
+  "ISC", # implicit string concatenation
+  "TCH", # type-checking imports
+  "C4", # comprehensions
+  "PGH" # pygrep-hooks
+]
+
+# Some additional rules that are useful
+lint.extend-select = [
+"UP009",  # UTF-8 encoding declaration is unnecessary
+"SIM118",  # Use `key in dict` instead of `key in dict.keys()`
+# "D205",  # One blank line required between summary line and description
+"ARG001",  # Unused function argument
+"RSE102",  # Unnecessary parentheses on raised exception
+"PERF401",  # Use a list comprehension to create a transformed list
+]
+
+lint.ignore = [
+  "ISC001", # Disable this for compatibility with ruff format
+  "B028", # No explicit `stacklevel` keyword argument found
+  "B905", # `zip()` without an explicit `strict=` parameter
+  "E402", # module level import not at top of file
+  "E731", # do not assign a lambda expression, use a def
+  "PLC1901", # compare-to-empty-string
+  "PLR0911", # Too many returns
+  "PLR0912", # Too many branches
+  "PLR0913", # Too many arguments to function call
+  "PLR0915", # Too many statements
+  "PLR2004", # Magic number
+]
+
+extend-exclude = [
+  "docs",
+  "roll_play.py",
+]
+
+[lint.pycodestyle]
+max-line-length = 100 # E501 reports lines that exceed the length of 100.
+
+[lint.extend-per-file-ignores]
+"__init__.py" = ["E402", "F401", "F403"]
+# For tests:
+# - D205: Don't worry about test docstrings
+# - ARG001: Unused function argument false positives for some fixtures
+# - E501: Line-too-long
+"**/tests/test_*.py" = ["D205", "ARG001", "E501"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,13 +2,31 @@ extend = "ruff-base.toml"
 
 extend-exclude = [
   "**/*.ipynb",
-  "obs*.py",
   "go.py",
   "go[0-9].py",
-  "junk/",
+  "roll_play.py",
 ]
 
-# Some additional rules that are useful
-lint.extend-select = [
-"D205",  # One blank line required between summary line and description
+# These are rules that commonly cause many ruff warnings. Code will be improved by
+# incrementally fixing code to adhere to these rules, but for practical purposes they
+# can be ignored by uncommenting each one. You can also add to this list as needed.
+lint.extend-ignore = [
+  "B905", # `zip()` without an explicit `strict=` parameter
+  "PLR0912", # Too many branches
+  "PLR0913", # Too many arguments to function call
+  "PLR0915", # Too many statements
+  # "PLC1901", # compare-to-empty-string
+  # "PLR0911", # Too many returns
+  # "PGH004", # Use specific rule codes when using `noqa`
+  # "C401", # Unnecessary generator (rewrite as a `set` comprehension)
+  # "C402", # Unnecessary generator (rewrite as a dict comprehension)
+  # "C405", # Unnecessary `list` literal (rewrite as a `set` literal)
+  # "C408", # Unnecessary `dict` call (rewrite as a literal)
+  # "C416", # Unnecessary `dict` comprehension (rewrite using `dict()`)
+  # "G010", # warn is deprecated in favor of warning
+  # "PYI056", # Calling `.append()` on `__all__` may not be supported by all type checkers
 ]
+
+[lint.extend-per-file-ignores]
+# B905 [*] `zip()` without an explicit `strict=` parameter
+"**/tests/test_*.py" = ["B905"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,63 +1,14 @@
-# Copied originally from pandas
-target-version = "py310"
+extend = "ruff-base.toml"
 
-# fix = true
-unfixable = []
-
-select = [
-  "I", # isort
-  "F", # pyflakes
-  "E", "W", # pycodestyle
-  "YTT", # flake8-2020
-  "B", # flake8-bugbear
-  "Q", # flake8-quotes
-  "T10", # flake8-debugger
-  "INT", # flake8-gettext
-  "PLC", "PLE", "PLR", "PLW", # pylint
-  "PIE", # misc lints
-  "PYI", # flake8-pyi
-  "TID", # tidy imports
-  "ISC", # implicit string concatenation
-  "TCH", # type-checking imports
-  "C4", # comprehensions
-  "PGH" # pygrep-hooks
+extend-exclude = [
+  "**/*.ipynb",
+  "obs*.py",
+  "go.py",
+  "go[0-9].py",
+  "junk/",
 ]
 
 # Some additional rules that are useful
-extend-select = [
-"UP009",  # UTF-8 encoding declaration is unnecessary
-"SIM118",  # Use `key in dict` instead of `key in dict.keys()`
+lint.extend-select = [
 "D205",  # One blank line required between summary line and description
-"ARG001",  # Unused function argument
-"RSE102",  # Unnecessary parentheses on raised exception
-"PERF401",  # Use a list comprehension to create a transformed list
 ]
-
-ignore = [
-  "ISC001", # Disable this for compatibility with ruff format
-  "B028", # No explicit `stacklevel` keyword argument found
-  "B905", # `zip()` without an explicit `strict=` parameter
-  "E402", # module level import not at top of file
-  "E731", # do not assign a lambda expression, use a def
-  "PLC1901", # compare-to-empty-string
-  "PLR0911", # Too many returns
-  "PLR0912", # Too many branches
-  "PLR0913", # Too many arguments to function call
-  "PLR0915", # Too many statements
-  "PLR2004", # Magic number
-]
-
-extend-exclude = [
-  "docs",
-]
-
-[pycodestyle]
-max-line-length = 100 # E501 reports lines that exceed the length of 100.
-
-[lint.extend-per-file-ignores]
-"__init__.py" = ["E402", "F401", "F403"]
-# For tests:
-# - D205: Don't worry about test docstrings
-# - ARG001: Unused function argument false positives for some fixtures
-"**/tests/test_*.py" = ["D205", "ARG001"]
-


### PR DESCRIPTION
## Description

This refactosr the ruff config into a base file which goes in `skare3/templates` and an extension to handle package-specific updates to the rules.

This uses the `ruff-base.toml` file in https://github.com/sot/skare3/pull/1269 and provides a demonstration of per-project extensions in `ruff.toml`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
No code changes.

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
`ruff .` and `ruff format` both succeed in the local repo.
