### PR TITLE
Update tests for proseco p2 overlap change

### DIFF
--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -896,7 +896,7 @@ def test_check_guide_geometry(aca_review_table):
     assert len(acar.messages) == 1
     msg = acar.messages[0]
     assert msg["category"] == "critical"
-    assert 'Guide indexes [4, 5, 6] clustered within 500" radius' in msg["text"]
+    assert 'Guide indexes [4, 7, 8] clustered within 500" radius' in msg["text"]
 
     # Test for cluster of 3 500" rad stars in a 5 star case, but downgrade
     # the warning for the case when the maneuver angle away is <= 5
@@ -915,7 +915,7 @@ def test_check_guide_geometry(aca_review_table):
     assert len(acar.messages) == 1
     msg = acar.messages[0]
     assert msg["category"] == "warning"
-    assert 'Guide indexes [4, 5, 6] clustered within 500" radius' in msg["text"]
+    assert 'Guide indexes [4, 7, 8] clustered within 500" radius' in msg["text"]
 
 
 def test_pickle():

--- a/sparkles/tests/test_yoshi.py
+++ b/sparkles/tests/test_yoshi.py
@@ -43,7 +43,7 @@ def test_run_one_yoshi(proseco_agasc_1p7):
         "n_warning": 1,
         "n_caution": 0,
         "n_info": 1,
-        "P2": 1.801521445484349,
+        "P2": 1.7923666714605953,
         "guide_count": 3.8577301426624357,
     }
 


### PR DESCRIPTION
## Description

Update tests for proseco p2 overlap change (in https://github.com/sot/proseco/pull/394)

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes the issue that environments with that updated overlap-p2 proseco version see this in the tests
```
(ska3-masters) jeanconn-fido> pytest 
================================================================================= test session starts =================================================================================
platform linux -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 103 items                                                                                                                                                                   

sparkles/tests/test_checks.py .......................................................................FF...                                                                      [ 73%]
sparkles/tests/test_find_er_catalog.py .....                                                                                                                                    [ 78%]
sparkles/tests/test_review.py ..................                                                                                                                                [ 96%]
sparkles/tests/test_yoshi.py F...                                                                                                                                               [100%]

====================================================================================== FAILURES
...
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

```
(ska3-masters) jeanconn-fido> pytest 
================================================================================= test session starts =================================================================================
platform linux -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 103 items                                                                                                                                                                   

sparkles/tests/test_checks.py ............................................................................                                                                      [ 73%]
sparkles/tests/test_find_er_catalog.py .....                                                                                                                                    [ 78%]
sparkles/tests/test_review.py ..................                                                                                                                                [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                                                               [100%]

=========================================================================== 103 passed in 85.72s (0:01:25) ============================================================================
(ska3-masters) jeanconn-fido> git rev-parse HEAD
ceccd8e712cbad4dfffede231222efdcebafe8b3
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
