### PR TITLE
Use a different bad star for bad star test

### DIFF
--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -763,7 +763,7 @@ def test_bad_star_set(aca_review_table):
             "category": "critical",
             "idx": 5,
         },
-        {'category': 'warning', 'text': 'P2: 2.39 less than 3.0 for OR'},
+        {"category": "warning", "text": "P2: 2.39 less than 3.0 for OR"},
         {"text": "OR requested 0 fids but 3 is typical", "category": "caution"},
         {"category": "info", "text": f"included guide ID(s): [{bad_id}]"},
     ]

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -745,9 +745,8 @@ def test_imposters_on_guide(exp_warn, aca_review_table):
 
 
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))
-def test_bad_star_set(proseco_agasc_1p7, aca_review_table):
-    # This faint star is no longer in proseco_agasc >= 1.8 so we use 1.7
-    bad_id = 1248994952
+def test_bad_star_set(aca_review_table):
+    bad_id = 260713672
     star = agasc.get_star(bad_id)
     ra = star["RA"]
     dec = star["DEC"]
@@ -760,17 +759,13 @@ def test_bad_star_set(proseco_agasc_1p7, aca_review_table):
     check_catalog(acar)
     assert acar.messages == [
         {
-            "text": "Guide star 1248994952 does not meet guide candidate criteria",
+            "text": f"Star {bad_id} is in proseco bad star set",
             "category": "critical",
             "idx": 5,
         },
-        {
-            "text": "Star 1248994952 is in proseco bad star set",
-            "category": "critical",
-            "idx": 5,
-        },
+        {'category': 'warning', 'text': 'P2: 2.39 less than 3.0 for OR'},
         {"text": "OR requested 0 fids but 3 is typical", "category": "caution"},
-        {"category": "info", "text": "included guide ID(s): [1248994952]"},
+        {"category": "info", "text": f"included guide ID(s): [{bad_id}]"},
     ]
 
 


### PR DESCRIPTION
## Description

Use a different bad star for bad star test

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes issue that the test was based on bad star 260713672, that was removed from the bad star list.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac arm64
```
(ska3) flame:sparkles jean$ git rev-parse HEAD
6a5fef42d6169c08a602c213e1995990bc233f32
(ska3) flame:sparkles jean$ pytest
========================================================================================== test session starts ==========================================================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 103 items                                                                                                                                                                                     

sparkles/tests/test_checks.py ............................................................................                                                                                        [ 73%]
sparkles/tests/test_find_er_catalog.py .....                                                                                                                                                      [ 78%]
sparkles/tests/test_review.py ..................                                                                                                                                                  [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                                                                                 [100%]

========================================================================================= 103 passed in 26.89s                                                                                                                                                                      
```

Independent check of unit tests by [REVIEWER NAME]
- [x] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
