### PR TITLE
Update sparkles tests for proseco no-color1 guide star change

### DIFF
--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -70,16 +70,17 @@ def test_review_catalog(proseco_agasc_1p7, tmpdir):
     acar.run_aca_review()
     assert acar.messages == [
         {
-            "text": "Guide star imposter offset 2.6, limit 2.5 arcsec",
             "category": "warning",
+            "text": "Guide star imposter offset 2.6, limit 2.5 arcsec",
             "idx": 4,
         },
-        {"text": "P2: 3.33 less than 4.0 for ER", "category": "warning"},
+        {"category": "warning", "text": "P2: 3.33 less than 4.0 for ER"},
         {
-            "text": "ER count of 9th (8.9 for -9.9C) mag guide stars 1.91 < 3.0",
             "category": "critical",
+            "text": "ER count of 9th (8.9 for -9.9C) mag guide stars 1.91 < 3.0",
         },
-        {"text": "ER with 6 guides but 8 were requested", "category": "caution"},
+        {"category": "critical", "text": "ER count of guide stars 5.00 < 6.0"},
+        {"category": "caution", "text": "ER with 5 guides but 8 were requested"},
     ]
 
     assert acar.roll_options is None
@@ -87,9 +88,10 @@ def test_review_catalog(proseco_agasc_1p7, tmpdir):
     msgs = acar.messages >= "critical"
     assert msgs == [
         {
-            "text": "ER count of 9th (8.9 for -9.9C) mag guide stars 1.91 < 3.0",
             "category": "critical",
-        }
+            "text": "ER count of 9th (8.9 for -9.9C) mag guide stars 1.91 < 3.0",
+        },
+        {"category": "critical", "text": "ER count of guide stars 5.00 < 6.0"},
     ]
 
     assert acar.review_status() == -1
@@ -336,16 +338,17 @@ def test_run_aca_review_function(proseco_agasc_1p7, tmpdir):
     assert exc is None
     assert acar.messages == [
         {
-            "text": "Guide star imposter offset 2.6, limit 2.5 arcsec",
             "category": "warning",
+            "text": "Guide star imposter offset 2.6, limit 2.5 arcsec",
             "idx": 4,
         },
-        {"text": "P2: 3.33 less than 4.0 for ER", "category": "warning"},
+        {"category": "warning", "text": "P2: 3.33 less than 4.0 for ER"},
         {
-            "text": "ER count of 9th (8.9 for -9.9C) mag guide stars 1.91 < 3.0",
             "category": "critical",
+            "text": "ER count of 9th (8.9 for -9.9C) mag guide stars 1.91 < 3.0",
         },
-        {"text": "ER with 6 guides but 8 were requested", "category": "caution"},
+        {"category": "critical", "text": "ER count of guide stars 5.00 < 6.0"},
+        {"category": "caution", "text": "ER with 5 guides but 8 were requested"},
     ]
 
     path = Path(str(tmpdir))
@@ -369,23 +372,24 @@ def test_run_aca_review_dyn_bgd_n_faint(proseco_agasc_1p7, tmpdir):
 
     assert exc is None
     assert acar.dyn_bgd_n_faint == 2
-    assert np.isclose(acar.guide_count, 6, atol=0.1)
+    assert np.isclose(acar.guide_count, 5, atol=0.1)
 
     # Assert same warnings as test_run_aca_review_function but with a different
     # guide count and new info message
     assert acar.messages == [
         {"text": "Using dyn_bgd_n_faint=2 (call_args val=0)", "category": "info"},
         {
-            "text": "Guide star imposter offset 2.6, limit 2.5 arcsec",
             "category": "warning",
+            "text": "Guide star imposter offset 2.6, limit 2.5 arcsec",
             "idx": 4,
         },
-        {"text": "P2: 3.33 less than 4.0 for ER", "category": "warning"},
+        {"category": "warning", "text": "P2: 3.33 less than 4.0 for ER"},
         {
-            "text": "ER count of 9th (8.9 for -9.9C) mag guide stars 1.91 < 3.0",
             "category": "critical",
+            "text": "ER count of 9th (8.9 for -9.9C) mag guide stars 1.91 < 3.0",
         },
-        {"text": "ER with 6 guides but 8 were requested", "category": "caution"},
+        {"category": "critical", "text": "ER count of guide stars 5.00 < 6.0"},
+        {"category": "caution", "text": "ER with 5 guides but 8 were requested"},
     ]
 
 


### PR DESCRIPTION
## Description

Update sparkles tests for proseco no-color1 guide star change (https://github.com/sot/proseco/pull/401)

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Tested in ska3-masters environment with https://github.com/sot/proseco/pull/401 

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-latest) flame:sparkles jean$ git rev-parse HEAD
56cad16c648ed8674c6527bb0ea010ea23e77a28
(ska3-flight-latest) flame:sparkles jean$ pytest
========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
PyQt5 5.15.9 -- Qt runtime 5.15.8 -- Qt compiled 5.15.8
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: astropy-0.11.0, qt-4.4.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, hypothesis-6.112.0, arraydiff-0.6.1, mock-3.14.0
collected 103 items                                                                                                                                                      

sparkles/tests/test_checks.py ............................................................................                                                         [ 73%]
sparkles/tests/test_find_er_catalog.py .....                                                                                                                       [ 78%]
sparkles/tests/test_review.py ..................                                                                                                                   [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                                                  [100%]

========================================================================== 103 passed in 29.18s
```

Independent check of unit tests by [REVIEWER NAME]
- [x] OSX
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
