### PR TITLE
set obsid report dir with a name consistent with proseco

### DIFF
--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -376,7 +376,7 @@ def _run_aca_review(
             # Note that the obs{aca.obsid} is not flexible because it must match the
             # convention used in ACATable.make_report().  Oops.
             aca.preview_dir = Path(report_dir)
-            aca.obsid_dir = aca.preview_dir / f"obs{aca.obsid}"
+            aca.obsid_dir = aca.preview_dir / f"obs{aca.obsid:05}"
             aca.obsid_dir.mkdir(parents=True, exist_ok=True)
 
             aca.make_starcat_plot()


### PR DESCRIPTION
## Description

This is a trivial change with no consequence in the usual cases. It only affected me because I ran `sparkles.run_aca_review` giving it a catalog with `obsid=0`. This resulted in some files saved into a directory called `obs0` and others in a directory called `obs00000` (because proseco does it [this way](https://github.com/sot/proseco/blob/a2f1012b84875ece373fb923e0ebed85d6f39b04/proseco/report_guide.py#L64) and [this way](https://github.com/sot/proseco/blob/a2f1012b84875ece373fb923e0ebed85d6f39b04/proseco/report_acq.py#L342)). This PR fixes that inconsistency.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

```
(ska3-flight-2024.9rc1) ~/SAO/git/sparkles obsid_dir $ pytest sparkles
============================================================= test session starts =============================================================
platform darwin -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 103 items                                                                                                                           

sparkles/tests/test_checks.py ............................................................................                              [ 73%]
sparkles/tests/test_find_er_catalog.py .....                                                                                            [ 78%]
sparkles/tests/test_review.py ..................                                                                                        [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                       [100%]

============================================================== warnings summary ===============================================================
sparkles/sparkles/tests/test_checks.py: 86 warnings
sparkles/sparkles/tests/test_find_er_catalog.py: 16 warnings
sparkles/sparkles/tests/test_review.py: 86 warnings
sparkles/sparkles/tests/test_yoshi.py: 2 warnings
  /Users/javierg/miniforge3/envs/ska3-flight-2024.9rc1/lib/python3.11/site-packages/tables/node.py:251: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    self._v_objectid = self._g_open()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== 103 passed, 190 warnings in 22.98s ======================================================
(ska3-flight-2024.9rc1) ~/SAO/git/sparkles obsid_dir $ git rev-parse HEAD
1c32959e979c611c5360feed525cb80cf1a331f0
```
Independent check of unit tests by @taldcroft
- [x] Mac

### Functional tests

I functionally tested this with aperoll (by default `obsid=0`), running sparkles, and checking the acq and guide reports.

TA: same functional test, also pass.
