### PR TITLE
Update a few tests to use old dyn_bgd_n_faint=0 default

### DIFF
--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -364,11 +364,12 @@ def test_guide_count_er5(aca_review_table):
 
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))
 def test_guide_count_or(aca_review_table):
-    """Test the check that an OR has enough fractional guide stars by guide_count"""
+    """Test the check that an OR has enough fractional guide stars by guide_count.
+    This test uses dyn_bgd_n_faint=0."""
     stars = StarsTable.empty()
     stars.add_fake_constellation(n_stars=5, mag=[7.0, 7.0, 10.3, 10.3, 10.3])
     aca = get_aca_catalog(
-        **mod_std_info(n_fid=3, n_guide=5, obsid=1),
+        **mod_std_info(n_fid=3, n_guide=5, obsid=1, dyn_bgd_n_faint=0),
         stars=stars,
         dark=DARK40,
         raise_exc=True,
@@ -426,13 +427,13 @@ def test_too_many_bright_stars(aca_review_table):
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))
 def test_low_guide_count(aca_review_table):
     """Test that a 3.5 to 4.0 guide_count observation gets a critical warning
-    on guide_count if man_angle_next > 5 (no creep-away)."""
+    on guide_count if man_angle_next > 5 (no creep-away). This test uses dyn_bgd_n_faint=0."""
     # Set a scenario with guide_count in the 3.5 to 4.0 range and confirm a
     # critical warning.
     stars = StarsTable.empty()
     stars.add_fake_constellation(n_stars=5, mag=[7.0, 7.0, 7.0, 10.2, 10.3])
     aca = get_aca_catalog(
-        **mod_std_info(n_fid=3, n_guide=5, obsid=1),
+        **mod_std_info(n_fid=3, n_guide=5, obsid=1, dyn_bgd_n_faint=0),
         stars=stars,
         dark=DARK40,
         raise_exc=True,
@@ -451,14 +452,16 @@ def test_low_guide_count(aca_review_table):
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))
 def test_low_guide_count_creep_away(aca_review_table):
     """Test that a 3.5 to 4.0 guide_count observation does not get a critical warning
-    on guide_count if man_angle_next <= 5 (creep-away)."""
+    on guide_count if man_angle_next <= 5 (creep-away).  This test uses dyn_bgd_n_faint=0."""
     # Set a scenario with guide_count in the 3.5 to 4.0 range but with
     # a creep away (maneuver angle <= 5), and confirm that is just a warning
     # (not critical).
     stars = StarsTable.empty()
     stars.add_fake_constellation(n_stars=5, mag=[7.0, 7.0, 7.0, 10.2, 10.3])
     aca = get_aca_catalog(
-        **mod_std_info(n_fid=3, n_guide=5, obsid=1, man_angle_next=5.0),
+        **mod_std_info(
+            n_fid=3, n_guide=5, obsid=1, man_angle_next=5.0, dyn_bgd_n_faint=0
+        ),
         stars=stars,
         dark=DARK40,
         raise_exc=True,

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -30,6 +30,7 @@ KWARGS_48464 = {
     "focus_offset": 0,
     "t_ccd_acq": -9.943,
     "t_ccd_guide": -9.938,
+    "dyn_bgd_n_faint": 0,
 }
 
 
@@ -282,6 +283,7 @@ def test_uniform_roll_options(proseco_agasc_1p7):
         "sim_offset": 0,
         "t_ccd_acq": -9.8,
         "t_ccd_guide": -9.8,
+        "dyn_bgd_n_faint": 0,
     }
 
     aca = get_aca_catalog(**kwargs)


### PR DESCRIPTION
## Description

Update a few tests to use old dyn_bgd_n_faint=0 default.

This PR is intended to go with https://github.com/sot/proseco/pull/403 , though explicitly adding dyn_bgd_n_faint=0 to a few tests does not require that version of proseco.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Tested with and without https://github.com/sot/proseco/pull/403  in PYTHONPATH .  Requires https://github.com/sot/proseco/pull/401 or proseco >= 5.15.0.

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-latest) flame:sparkles jean$ python -c "import proseco; print(proseco.__version__)"
5.15.1.dev4+g09710b0
(ska3-flight-latest) flame:sparkles jean$ git rev-parse HEAD
61a57818bf7c93c38843a13f679ebbf4fef39129
(ska3-flight-latest) flame:sparkles jean$ pytest
=========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
PyQt5 5.15.9 -- Qt runtime 5.15.8 -- Qt compiled 5.15.8
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: astropy-0.11.0, qt-4.4.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, hypothesis-6.112.0, arraydiff-0.6.1, mock-3.14.0
collected 103 items                                                                                                                                                       

sparkles/tests/test_checks.py ............................................................................                                                          [ 73%]
sparkles/tests/test_find_er_catalog.py .....                                                                                                                        [ 78%]
sparkles/tests/test_review.py ..................                                                                                                                    [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                                                   [100%]

========================================================================== 103 passed in 26.68s
```

Independent check of unit tests by @taldcroft:
- [x] Mac

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
