### PR TITLE
Apply dynamic background bonus to rolled "n_stars"

### DIFF
--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -264,6 +264,60 @@ def test_roll_options_with_monitor_star():
     acar.get_roll_options()
 
 
+def test_roll_options_use_dyn_bgd_n_faint():
+    """Test that the roll options use dyn_bgd_n_faint in the catalog
+    selection and the n_stars value.  This test uses an artificially large
+    dyn_bgd_t_ccd of -10 accentuate the differences."""
+
+    kwargs = {
+        "att": [-0.63787389, 0.07940607, -0.10873119, 0.75828036],
+        "date": "2024:316",
+        "detector": "ACIS-S",
+        "dither": (16, 16),
+        "focus_offset": 0,
+        "sim_offset": 0,
+        "man_angle": 5,
+        "n_acq": 8,
+        "n_fid": 3,
+        "n_guide": 5,
+        "obsid": 30580,
+        "t_ccd": -6.0,
+    }
+
+    aca1_n_faint = 0
+    aca1 = get_aca_catalog(**kwargs, dyn_bgd_n_faint=aca1_n_faint, dyn_bgd_dt_ccd=-10)
+    acar1 = aca1.get_review_table()
+    acar1.get_roll_options()
+
+    aca2_n_faint = 3
+    aca2 = get_aca_catalog(**kwargs, dyn_bgd_n_faint=aca2_n_faint, dyn_bgd_dt_ccd=-10)
+    acar2 = aca2.get_review_table()
+    acar2.get_roll_options()
+
+    assert acar1.dyn_bgd_n_faint == aca1_n_faint
+    assert acar2.dyn_bgd_n_faint == aca2_n_faint
+    for roll_option in acar1.roll_options:
+        assert roll_option["acar"].dyn_bgd_n_faint == aca1_n_faint
+    for roll_option in acar2.roll_options:
+        assert roll_option["acar"].dyn_bgd_n_faint == aca2_n_faint
+
+    aca1_n_stars = [roll_option["n_stars"] for roll_option in acar1.roll_options]
+    aca2_n_stars = [roll_option["n_stars"] for roll_option in acar2.roll_options]
+
+    # In these cases the roll options are the same.
+    assert len(aca1_n_stars) == len(aca2_n_stars)
+
+    # But the guide count of the last one is not.
+    assert np.allclose(
+        np.array(aca1_n_stars),
+        np.array([1.5302331230204111, 1.5302331230204111, 2.5306029287208744]),
+    )
+    assert np.allclose(
+        np.array(aca2_n_stars),
+        np.array([1.5302331230204111, 1.5302331230204111, 3.530615379948673]),
+    )
+
+
 def test_uniform_roll_options(proseco_agasc_1p7):
     """Use obsid 22508 as a test case for failing to find a roll option using
     the 'uniq_ids' algorithm and falling through to a 'uniform' search.


### PR DESCRIPTION
## Description

Apply dynamic background bonus to rolled "n_stars".

The catalogs in roll optimization were correctly carrying forward any dynamic background options (dyn_bgd_n_faint, dyn_bgd_dt_ccd) but these options were not applied to the optimized "n_stars".  This PR fixes that for consistency.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
n_stars in the roll optimization table should now match the "final" catalog guide_count used in operations, if the same input kwargs for proseco are used.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac with a recent ska3-flight-latest
```
(ska3-flight-latest) flame:sparkles jean$ git rev-parse HEAD
ab4628e8d2f629d6c42d9d1af60f0064c9e7261c
(ska3-flight-latest) flame:sparkles jean$ pytest
=============================================== test session starts ===============================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
PyQt5 5.15.9 -- Qt runtime 5.15.8 -- Qt compiled 5.15.8
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: astropy-0.11.0, qt-4.4.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, hypothesis-6.112.0, arraydiff-0.6.1, mock-3.14.0
collected 104 items                                                                                               

sparkles/tests/test_checks.py ............................................................................  [ 73%]
sparkles/tests/test_find_er_catalog.py .....                                                                [ 77%]
sparkles/tests/test_review.py ...................                                                           [ 96%]
sparkles/tests/test_yoshi.py ....                                                                           [100%]

============================================== 104 passed in 28.53s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
New unit test added.
