### PR TITLE
Fix roll optimize deepcopy issue and fix warning in tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.2.2
+  rev: v0.8.5
   hooks:
     # Run the linter.
     - id: ruff

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -5,7 +5,6 @@ Roll optimization during preliminary review of ACA catalogs.
 """
 
 import warnings
-from copy import deepcopy
 
 import numpy as np
 import ska_sun
@@ -367,8 +366,19 @@ class RollOptimizeMixin:
 
         att_targ = self.att_targ
 
-        # Special case, first roll option is self but with obsid set to roll
-        acar = deepcopy(self)
+        # Special case, first roll option is self but with obsid set to roll. Note that
+        # the "copy" from the line below is not a full deep copy of the table meta
+        # because it runs the __init__ method. This initializes the MetaAttributes to
+        # their default states instead of copying them. This is *required* for this code
+        # to work.
+        #
+        # As a development note, this used to be deepcopy(self), but in astropy 7.0 the
+        # implementation changed so that the meta dict was explicitly deepcopied after
+        # the __init__ call. This caused the MetaAttributes to be set to the original
+        # self values and the code to fail. The line below is the astropy 6.0 code for
+        # implementing deepcopy().
+        acar = self.copy(copy_data=True)
+
         check_catalog(acar)
         acar.is_roll_option = True
         roll_options = [

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -377,6 +377,11 @@ class RollOptimizeMixin:
         # the __init__ call. This caused the MetaAttributes to be set to the original
         # self values and the code to fail. The line below is the astropy 6.0 code for
         # implementing deepcopy().
+        #
+        # See also https://github.com/sot/sparkles/pull/220/files#r1903130172 for more
+        # discussion and some clarification (maybe). One idea is to make do
+        # deepcopy(self) and not re-run check_catalog(); OR, make a brand new catalog
+        # from self.call_args.
         acar = self.copy(copy_data=True)
 
         check_catalog(acar)

--- a/sparkles/tests/test_find_er_catalog.py
+++ b/sparkles/tests/test_find_er_catalog.py
@@ -90,9 +90,9 @@ TEST_COLS = [
 def test_find_er_catalog_minus_2_pitch_bins(proseco_agasc_1p7, ACA, ATTS):
     # Try it all for the bad field near PKS 0023-26
     acar, att_opts = find_er_catalog(ACA, ATTS, alg="pitch_bins")
-    # import pprint; pprint.pprint(att_opts[TEST_COLS].pformat_all(), width=100)
+    # import pprint; pprint.pprint(att_opts[TEST_COLS].pformat(), width=100)
     assert acar is att_opts["acar"][8]
-    assert att_opts[TEST_COLS].pformat_all() == [
+    assert att_opts[TEST_COLS].pformat() == [
         "dpitch  dyaw count_9th count_10th count_all count_ok n_critical        att       ",
         "------ ----- --------- ---------- --------- -------- ---------- -----------------",
         " -0.01  3.10      4.18       6.00      5.65     True          2  7.66 -25.21 29.3",
@@ -112,9 +112,9 @@ def test_find_er_catalog_minus_2_pitch_bins(proseco_agasc_1p7, ACA, ATTS):
 
 def test_find_er_catalog_minus_2_count_all(proseco_agasc_1p7, ACA, ATTS):
     acar, att_opts = find_er_catalog(ACA, ATTS, alg="count_all")
-    # import pprint; pprint.pprint(att_opts[TEST_COLS].pformat_all(), width=100)
+    # import pprint; pprint.pprint(att_opts[TEST_COLS].pformat(), width=100)
     assert acar is att_opts["acar"][8]
-    assert att_opts[TEST_COLS].pformat_all() == [
+    assert att_opts[TEST_COLS].pformat() == [
         "dpitch  dyaw count_9th count_10th count_all count_ok n_critical        att       ",
         "------ ----- --------- ---------- --------- -------- ---------- -----------------",
         " -0.01  3.10      4.18       6.00      5.65     True         --  7.66 -25.21 29.3",
@@ -134,9 +134,9 @@ def test_find_er_catalog_minus_2_count_all(proseco_agasc_1p7, ACA, ATTS):
 
 def test_find_er_catalog_minus_2_input_order(proseco_agasc_1p7, ACA, ATTS):
     acar, att_opts = find_er_catalog(ACA, ATTS, alg="input_order")
-    # import pprint; pprint.pprint(att_opts[TEST_COLS].pformat_all(), width=100)
+    # import pprint; pprint.pprint(att_opts[TEST_COLS].pformat(), width=100)
     assert acar is att_opts["acar"][8]
-    assert att_opts[TEST_COLS].pformat_all() == [
+    assert att_opts[TEST_COLS].pformat() == [
         "dpitch  dyaw count_9th count_10th count_all count_ok n_critical        att       ",
         "------ ----- --------- ---------- --------- -------- ---------- -----------------",
         " -0.01  3.10      4.18       6.00      5.65     True          2  7.66 -25.21 29.3",

--- a/sparkles/tests/test_yoshi.py
+++ b/sparkles/tests/test_yoshi.py
@@ -171,4 +171,4 @@ def test_acar_from_ocat(proseco_agasc_1p7):
     ]
 
     cols = ("idx", "slot", "id", "type", "mag", "yang", "zang")
-    assert acar[cols].pformat_all() == exp
+    assert acar[cols].pformat() == exp


### PR DESCRIPTION
## Description

This fixes a [problem seen in testing of 2025.1rc2](https://chandramission.slack.com/archives/G01LN40AXPG/p1735926353950679), with the root cause being a changed introduced by  https://github.com/astropy/astropy/pull/15871.

It also makes a non-impacting change in tests to use `Table.pformat()` instead of `Table.pformat_all()`, since they are equivalent in astropy >= 7.0.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
ska3-flight-2025.0rc2) ➜  sparkles git:(fix-roll-optimize-deepcopy-issue) git rev-parse --short HEAD
c003f24
(ska3-flight-2025.0rc2) ➜  sparkles git:(fix-roll-optimize-deepcopy-issue) pytest                    
================================================= test session starts =================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 104 items                                                                                                   

sparkles/tests/test_checks.py ............................................................................      [ 73%]
sparkles/tests/test_find_er_catalog.py .....                                                                    [ 77%]
sparkles/tests/test_review.py ...................                                                               [ 96%]
sparkles/tests/test_yoshi.py ....                                                                               [100%]

================================================ 104 passed in 29.43s =================================================
```

Independent check of unit tests by Javier
- [x] Linux
```
(ska3-flight-2025.0rc4) jgonzale sparkles $ pytest sparkles/
============================================================= test session starts =============================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 104 items                                                                                                                           

sparkles/tests/test_checks.py ............................................................................                              [ 73%]
sparkles/tests/test_find_er_catalog.py .....                                                                                            [ 77%]
sparkles/tests/test_review.py ...................                                                                                       [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                       [100%]

======================================================= 104 passed in 80.71s (0:01:20) ========================================================
(ska3-flight-2025.0rc4) jgonzale sparkles $ git rev-parse --short HEAD
c003f24
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
