### PR TITLE
Check close-to-zero dither observations meet requirements

### DIFF
--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -56,7 +56,7 @@ def check_guide_overlap(acar: ACACheckTable) -> list[Message]:
         if np.abs(drow) <= 12 and np.abs(dcol) <= 12:
             msg = (
                 "Overlapping track index (within 12 pix) "
-                f'idx [{entry1["idx"]}] and idx [{entry2["idx"]}]'
+                f"idx [{entry1['idx']}] and idx [{entry2['idx']}]"
             )
             msgs += [Message("critical", msg)]
     return msgs
@@ -464,7 +464,7 @@ def check_bad_stars(entry: ACACatalogTableRow) -> list[Message]:
     """
     msgs = []
     if entry["id"] in ACA.bad_star_set:
-        msg = f'Star {entry["id"]} is in proseco bad star set'
+        msg = f"Star {entry['id']} is in proseco bad star set"
         msgs += [Message("critical", msg, idx=entry["idx"])]
     return msgs
 
@@ -486,8 +486,8 @@ def check_fid_spoiler_score(idx, fid) -> list[Message]:
 
     for spoiler in fid["spoilers"]:
         msg = (
-            f'Fid {fid_id} has {spoiler["warn"]} spoiler: star {spoiler["id"]} with'
-            f' mag {spoiler["mag"]:.2f}'
+            f"Fid {fid_id} has {spoiler['warn']} spoiler: star {spoiler['id']} with"
+            f" mag {spoiler['mag']:.2f}"
         )
         msgs += [Message(category_map[spoiler["warn"]], msg, idx=idx)]
     return msgs

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -357,20 +357,19 @@ def check_dither(acar: ACACheckTable) -> list[Message]:
 def check_config_for_no_guide_dither(acar: ACACheckTable) -> list[Message]:
     """Check special configurations for no guide dither."""
     msgs = []
-
-    if acar.dither_guide.y < 1.0 and acar.dither_guide.z < 1.0:
+    if np.round(acar.dither_guide.y, 0) == 0 and np.round(acar.dither_guide.z, 0) == 0:
         if acar.dyn_bgd_n_faint > 0:
             msgs += [
                 Message(
                     "critical",
-                    "guide_dither < 1x1 arcsec and dyn_bgd_n_faint > 0",
+                    "guide_dither close to 0 arcsec and dyn_bgd_n_faint > 0",
                 )
             ]
         if acar.man_angle_next > CREEP_AWAY_THRESHOLD:
             msgs += [
                 Message(
                     "critical",
-                    f"guide_dither < 1x1 arcsec and man_angle_next > {CREEP_AWAY_THRESHOLD}",
+                    f"guide_dither close to 0 arcsec and man_angle_next > {CREEP_AWAY_THRESHOLD}",
                 )
             ]
     return msgs

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -354,6 +354,28 @@ def check_dither(acar: ACACheckTable) -> list[Message]:
     return msgs
 
 
+def check_config_for_no_guide_dither(acar: ACACheckTable) -> list[Message]:
+    """Check special configurations for no guide dither."""
+    msgs = []
+
+    if acar.dither_guide.y < 1.0 and acar.dither_guide.z < 1.0:
+        if acar.dyn_bgd_n_faint > 0:
+            msgs += [
+                Message(
+                    "critical",
+                    "guide_dither < 1x1 arcsec and dyn_bgd_n_faint > 0",
+                )
+            ]
+        if acar.man_angle_next > CREEP_AWAY_THRESHOLD:
+            msgs += [
+                Message(
+                    "critical",
+                    f"guide_dither < 1x1 arcsec and man_angle_next > {CREEP_AWAY_THRESHOLD}",
+                )
+            ]
+    return msgs
+
+
 def check_pos_err_guide(acar: ACACheckTable, star: StarsTableRow) -> list[Message]:
     """Warn on stars with larger POS_ERR (warning at 1" critical at 2")"""
     msgs = []

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -867,7 +867,7 @@ class ACAReviewTable(ACACheckTable, RollOptimizeMixin):
                 ax.text(
                     star["row"] + 24,
                     star["col"],
-                    f'{star["mag"]:.2f}',
+                    f"{star['mag']:.2f}",
                     ha="left",
                     va="center",
                     fontsize="small",

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1019,6 +1019,9 @@ Predicted Acq CCD temperature (init) : {self.t_ccd_acq:.1f}{t_ccd_eff_acq_msg}""
 check_acq_p2 = checks.acar_check_wrapper(checks.check_acq_p2)
 check_bad_stars = checks.acar_check_wrapper(checks.check_bad_stars)
 check_dither = checks.acar_check_wrapper(checks.check_dither)
+check_config_for_no_guide_dither = checks.acar_check_wrapper(
+    checks.check_config_for_no_guide_dither
+)
 check_fid_count = checks.acar_check_wrapper(checks.check_fid_count)
 check_fid_spoiler_score = checks.acar_check_wrapper(checks.check_fid_spoiler_score)
 check_guide_count = checks.acar_check_wrapper(checks.check_guide_count)

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1068,6 +1068,7 @@ def check_catalog(acar: ACACheckTable) -> None:
     msgs += checks.check_acq_p2(acar)
     msgs += checks.check_guide_count(acar)
     msgs += checks.check_dither(acar)
+    msgs += checks.check_config_for_no_guide_dither(acar)
     msgs += checks.check_fid_count(acar)
     msgs += checks.check_include_exclude(acar)
 

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -507,13 +507,15 @@ def test_no_dither_setup(aca_review_table):
     """ """
     stars = StarsTable.empty()
     stars.add_fake_constellation(n_stars=5, mag=[7.0, 7.0, 7.0, 8.0, 9.0])
+    # Set up an observation with super-tiny dither but with
+    # dyn_bgd_n_faint at the 2 default and man_angle_next > 5
     aca = get_aca_catalog(
         **mod_std_info(
             n_fid=3,
             n_guide=5,
             obsid=1,
             dyn_bgd_n_faint=2,
-            dither=(0, 0),
+            dither=(0.2, 0),
             man_angle_next=20,
         ),
         stars=stars,
@@ -527,11 +529,11 @@ def test_no_dither_setup(aca_review_table):
     assert acar.messages == [
         {
             "category": "critical",
-            "text": "guide_dither < 1x1 arcsec and dyn_bgd_n_faint > 0",
+            "text": "guide_dither close to 0 arcsec and dyn_bgd_n_faint > 0",
         },
         {
             "category": "critical",
-            "text": "guide_dither < 1x1 arcsec and man_angle_next > 5.0",
+            "text": "guide_dither close to 0 arcsec and man_angle_next > 5.0",
         },
     ]
 

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -19,6 +19,7 @@ from sparkles.aca_check_table import ACACheckTable
 from sparkles.core import (
     check_acq_p2,
     check_catalog,
+    check_config_for_no_guide_dither,
     check_dither,
     check_guide_count,
     check_guide_geometry,
@@ -499,6 +500,42 @@ def test_reduced_dither_low_guide_count(aca_review_table):
     # Run the dither check
     check_dither(acar)
     assert len(acar.messages) == 0
+
+
+@pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))
+def test_no_dither_setup(aca_review_table):
+    """ """
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(n_stars=5, mag=[7.0, 7.0, 7.0, 8.0, 9.0])
+    aca = get_aca_catalog(
+        **mod_std_info(
+            n_fid=3,
+            n_guide=5,
+            obsid=1,
+            dyn_bgd_n_faint=2,
+            dither=(0, 0),
+            man_angle_next=20,
+        ),
+        stars=stars,
+        dark=DARK40,
+        raise_exc=True,
+    )
+    acar = aca_review_table(aca)
+
+    # Run the dither check
+    check_config_for_no_guide_dither(acar)
+    assert acar.messages == [
+        {
+            "category": "critical",
+            "text": "guide_dither < 1x1 arcsec and dyn_bgd_n_faint > 0",
+        },
+        {
+            "category": "critical",
+            "text": "guide_dither < 1x1 arcsec and man_angle_next > 5.0",
+        },
+    ]
+
+    assert len(acar.messages) == 2
 
 
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -56,11 +56,11 @@ def test_t_ccd_effective_message():
         kwargs["t_ccd_acq"] + 1 + (kwargs["t_ccd_acq"] - ACA.aca_t_ccd_penalty_limit)
     )
     assert (
-        f'Predicted Guide CCD temperature (max): {kwargs["t_ccd_guide"]:.1f} '
+        f"Predicted Guide CCD temperature (max): {kwargs['t_ccd_guide']:.1f} "
         f'<span class="caution">(Effective : {eff_guide:.1f})</span>' in text
     )
     assert (
-        f'Predicted Acq CCD temperature (init) : {kwargs["t_ccd_acq"]:.1f} '
+        f"Predicted Acq CCD temperature (init) : {kwargs['t_ccd_acq']:.1f} "
         f'<span class="caution">(Effective : {eff_acq:.1f})</span>' in text
     )
 


### PR DESCRIPTION
## Description

Check close-to-zero dither observations meets requirements:

- no dynamic background
- creep-away


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3) flame:sparkles jean$ git rev-parse HEAD
bba942878fd00cd2d83f719c837e8988c6936969
(ska3) flame:sparkles jean$ pytest
============================================================ test session starts =============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 106 items                                                                                                                          

sparkles/tests/test_checks.py ..............................................................................                           [ 73%]
sparkles/tests/test_find_er_catalog.py .....                                                                                           [ 78%]
sparkles/tests/test_review.py ...................                                                                                      [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                      [100%]

============================================================ 106 passed in 32.06s
```
Independent check of unit tests by @taldcroft 
- [x] Mac
```
(ska3) ➜  sparkles git:(no-dither) git rev-parse --short HEAD
9543c19
(ska3) ➜  sparkles git:(no-dither) pytest
============================================= test session starts =============================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Volumes/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 106 items                                                                                           

sparkles/tests/test_checks.py ......................................................................... [ 68%]
.....                                                                                                   [ 73%]
sparkles/tests/test_find_er_catalog.py .....                                                            [ 78%]
sparkles/tests/test_review.py ...................                                                       [ 96%]
sparkles/tests/test_yoshi.py ....                                                                       [100%]

============================================ 106 passed in 33.44s =============================================
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
New trivial unit test added.

For functional testing, I edited the proseco pickle file for JAN0325A and set the dither_guide to (0, 0) in observations 29897 and 30718 (both really had 0 dither) and in obsid 30712 (just an arbitrary observation).

In obsid 30718 I also updated dyn_bgd_n_faint = 0, but I left dyn_bgd_n_faint set to 2 for obsids 29897 and 30712.
Obsid 30712 also has a maneuver greater than 5 (expected because this was just an arbitrary observation for the test).

The warnings are correct for the configurations in the functional output at

https://icxc.cfa.harvard.edu/aspect/test_review_outputs/sparkles/sparkles-pr221/JAN0325A_patched_sparkles/
