### PR TITLE
Run Jupiter checks

### DIFF
--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -89,6 +89,9 @@ def check_run_jupiter_checks(acar: ACACheckTable) -> list[Message]:
     # First check for exclude dates when Jupiter is fainter than the Optically Bright
     # Object limit of -2.0 mag.
     if jupiter.date_is_excluded(acar.date):
+        msgs += [
+            Message("info", "Jupiter fainter than -2.0 mag - no Jupiter checks run")
+        ]
         return msgs
 
     msgs += check_jupiter_on_ccd(acar)
@@ -96,7 +99,7 @@ def check_run_jupiter_checks(acar: ACACheckTable) -> list[Message]:
     msgs += check_jupiter_track_spoilers(acar)
     msgs += check_jupiter_distribution(acar)
 
-    msgs += [Message("info", "Ran Jupiter checks")]
+    msgs += [Message("info", "Jupiter mag <= -2.0. Ran Partial OBO Mitigation checks.")]
     return msgs
 
 

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -82,21 +82,24 @@ def check_run_jupiter_checks(acar: ACACheckTable) -> list[Message]:
     list of Message
         List of messages from the jupiter checks.
     """
+    msgs = []
     # First check for exclude dates
     if jupiter.date_is_excluded(acar.date):
-        return []
+        return msgs
 
     # Get jupiter position
     jupiter_pos = jupiter.get_jupiter_position(
         date=acar.date, duration=acar.duration, att=acar.att
     )
     if jupiter_pos is None:
-        return []
+        msgs += [Message("critical", "No Jupiter position found")]
+        return msgs
 
-    msgs = []
     msgs += check_jupiter_acq_spoilers(acar, jupiter_pos)
     msgs += check_jupiter_track_spoilers(acar, jupiter_pos)
     msgs += check_jupiter_distribution(acar, jupiter_pos)
+
+    msgs += [Message("info", "Ran Jupiter checks")]
     return msgs
 
 

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -84,14 +84,14 @@ def check_run_jupiter_checks(acar: ACACheckTable) -> list[Message]:
     """
     # First check for exclude dates
     if jupiter.date_is_excluded(acar.date):
-        return
+        return []
 
     # Get jupiter position
     jupiter_pos = jupiter.get_jupiter_position(
         date=acar.date, duration=acar.duration, att=acar.att
     )
     if jupiter_pos is None:
-        return
+        return []
 
     msgs = []
     msgs += check_jupiter_acq_spoilers(acar, jupiter_pos)
@@ -131,7 +131,7 @@ def check_jupiter_acq_spoilers(
 
     _, jcol = get_jupiter_acq_pos(acar.date, jupiter_pos)
     if jcol is None:
-        return
+        return []
 
     # For each acquisition box confirm a column spoiled by jupiter isn't in it
     for entry in acqs:

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -91,7 +91,7 @@ def check_run_jupiter_checks(acar: ACACheckTable) -> list[Message]:
     jupiter_pos = jupiter.get_jupiter_position(
         date=acar.date, duration=acar.duration, att=acar.att
     )
-    if jupiter_pos is None:
+    if len(jupiter_pos) == 0:
         msgs += [Message("critical", "No Jupiter position found")]
         return msgs
 

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -118,7 +118,7 @@ def check_jupiter_on_ccd(acar: ACACheckTable) -> list[Message]:
     if len(acar.jupiter) == 0:
         msgs += [
             Message(
-                "critical",
+                "warning",
                 f"Jupiter not on CCD, expected for target '{acar.target_name}'",
             )
         ]

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1029,6 +1029,16 @@ check_guide_fid_position_on_ccd = checks.acar_check_wrapper(
     checks.check_guide_fid_position_on_ccd
 )
 check_guide_geometry = checks.acar_check_wrapper(checks.check_guide_geometry)
+check_run_jupiter_checks = checks.acar_check_wrapper(checks.check_run_jupiter_checks)
+check_jupiter_acq_spoilers = checks.acar_check_wrapper(
+    checks.check_jupiter_acq_spoilers
+)
+check_jupiter_track_spoilers = checks.acar_check_wrapper(
+    checks.check_jupiter_track_spoilers
+)
+check_jupiter_distribution = checks.acar_check_wrapper(
+    checks.check_jupiter_distribution
+)
 check_guide_is_candidate = checks.acar_check_wrapper(checks.check_guide_is_candidate)
 check_guide_overlap = checks.acar_check_wrapper(checks.check_guide_overlap)
 check_imposters_guide = checks.acar_check_wrapper(checks.check_imposters_guide)
@@ -1064,7 +1074,14 @@ def check_catalog(acar: ACACheckTable) -> None:
             msgs += checks.check_fid_spoiler_score(entry["idx"], fid)
 
     msgs += checks.check_guide_overlap(acar)
+
+    # If the target_name includes "jupiter" then check for Jupiter stars
+    # - otherwise check the guide geometry.
+    if acar.target_name is not None and "jupiter" in acar.target_name.lower():
+        msgs += checks.check_run_jupiter_checks(acar)
+
     msgs += checks.check_guide_geometry(acar)
+
     msgs += checks.check_acq_p2(acar)
     msgs += checks.check_guide_count(acar)
     msgs += checks.check_dither(acar)

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1016,6 +1016,8 @@ Predicted Acq CCD temperature (init) : {self.t_ccd_acq:.1f}{t_ccd_eff_acq_msg}""
         return acar
 
 
+# TODO: are these definitions needed in core.py? I think they are just used in
+# testing because the original checks were written for ACAReviewTable.
 check_acq_p2 = checks.acar_check_wrapper(checks.check_acq_p2)
 check_bad_stars = checks.acar_check_wrapper(checks.check_bad_stars)
 check_dither = checks.acar_check_wrapper(checks.check_dither)
@@ -1074,13 +1076,8 @@ def check_catalog(acar: ACACheckTable) -> None:
             msgs += checks.check_fid_spoiler_score(entry["idx"], fid)
 
     msgs += checks.check_guide_overlap(acar)
-
-    # If the target_name includes "jupiter" then run jupiter checks.
-    if acar.target_name is not None and "jupiter" in acar.target_name.lower():
-        msgs += checks.check_run_jupiter_checks(acar)
-
+    msgs += checks.check_run_jupiter_checks(acar)
     msgs += checks.check_guide_geometry(acar)
-
     msgs += checks.check_acq_p2(acar)
     msgs += checks.check_guide_count(acar)
     msgs += checks.check_dither(acar)

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1075,8 +1075,7 @@ def check_catalog(acar: ACACheckTable) -> None:
 
     msgs += checks.check_guide_overlap(acar)
 
-    # If the target_name includes "jupiter" then check for Jupiter stars
-    # - otherwise check the guide geometry.
+    # If the target_name includes "jupiter" then run jupiter checks.
     if acar.target_name is not None and "jupiter" in acar.target_name.lower():
         msgs += checks.check_run_jupiter_checks(acar)
 

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -56,7 +56,7 @@ def test_check_jupiter_acq_spoilers_fail(aca_review_table):
         **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
     )
     acar = aca_review_table(aca)
-    jupiter_pos = Table(
+    acar.jupiter = Table(
         [
             {
                 "time": CxoTime(acar.date).secs,
@@ -65,7 +65,7 @@ def test_check_jupiter_acq_spoilers_fail(aca_review_table):
             }
         ]
     )
-    check_jupiter_acq_spoilers(acar, jupiter_pos)
+    check_jupiter_acq_spoilers(acar)
     assert acar.messages == [
         {
             "category": "critical",
@@ -88,8 +88,8 @@ def test_check_jupiter_acq_spoilers_none(aca_review_table):
         **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
     )
     acar = aca_review_table(aca)
-    jupiter_pos = Table([{"time": CxoTime(acar.date).secs, "row": 0, "col": 100}])
-    check_jupiter_acq_spoilers(acar, jupiter_pos)
+    acar.jupiter = Table([{"time": CxoTime(acar.date).secs, "row": 0, "col": 100}])
+    check_jupiter_acq_spoilers(acar)
     assert acar.messages == []
 
 
@@ -102,8 +102,8 @@ def test_check_jupiter_track_spoilers_true(aca_review_table):
         **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
     )
     acar = aca_review_table(aca)
-    jupiter_pos = Table([{"time": CxoTime(acar.date).secs, "row": 0, "col": 0}])
-    check_jupiter_track_spoilers(acar, jupiter_pos)
+    acar.jupiter = Table([{"time": CxoTime(acar.date).secs, "row": 0, "col": 0}])
+    check_jupiter_track_spoilers(acar)
     assert acar.messages == [
         {
             "category": "critical",
@@ -128,8 +128,8 @@ def test_check_jupiter_track_spoilers_false(aca_review_table):
     )
     acar = aca_review_table(aca)
     # For this test, move Jupiter so it doesn't spoil the stars
-    jupiter_pos = Table([{"time": CxoTime(acar.date).secs, "row": 40, "col": 50}])
-    check_jupiter_track_spoilers(acar, jupiter_pos)
+    acar.jupiter = Table([{"time": CxoTime(acar.date).secs, "row": 40, "col": 50}])
+    check_jupiter_track_spoilers(acar)
     assert acar.messages == []
 
 
@@ -144,8 +144,8 @@ def test_check_jupiter_distribution_fail(aca_review_table):
         **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
     )
     acar = aca_review_table(aca)
-    jupiter_pos = Table([{"time": CxoTime(acar.date).secs, "row": 300, "col": 10}])
-    check_jupiter_distribution(acar, jupiter_pos)
+    acar.jupiter = Table([{"time": CxoTime(acar.date).secs, "row": 300, "col": 10}])
+    check_jupiter_distribution(acar)
     assert acar.messages == [
         {
             "category": "critical",
@@ -160,8 +160,8 @@ def test_check_jupiter_distribution_fine(aca_review_table):
     stars.add_fake_constellation(n_stars=3, mag=8.5)
     aca = get_aca_catalog(**STD_INFO, duration=20000, stars=stars, dark=DARK40)
     acar = aca_review_table(aca)
-    jupiter_pos = Table([{"time": CxoTime(acar.date).secs, "row": -300, "col": 10}])
-    check_jupiter_distribution(acar, jupiter_pos)
+    acar.jupiter = Table([{"time": CxoTime(acar.date).secs, "row": -300, "col": 10}])
+    check_jupiter_distribution(acar)
     assert acar.messages == []
 
 
@@ -173,7 +173,7 @@ def test_check_jupiter_distribution_cross(aca_review_table):
     aca = get_aca_catalog(**STD_INFO, duration=20000, stars=stars, dark=DARK40)
     acar = aca_review_table(aca)
     # And have Jupiter cross the center
-    jupiter_pos = Table(
+    acar.jupiter = Table(
         [
             {"time": CxoTime(acar.date).secs, "row": -300, "col": 10},
             {"time": CxoTime(acar.date).secs + 1000, "row": 300, "col": 10},
@@ -181,7 +181,7 @@ def test_check_jupiter_distribution_cross(aca_review_table):
     )
     # There is no way to satisfy the distribution requirement with 3 stars
     # and Jupiter crossing.
-    check_jupiter_distribution(acar, jupiter_pos)
+    check_jupiter_distribution(acar)
     assert acar.messages == [
         {
             "category": "critical",

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -34,6 +34,52 @@ KWARGS_48464 = {
 }
 
 
+def test_jupiter_present():
+    """Test that Jupiter checks run nominally for an observation in 2025 with Jupiter
+    present and in target name"""
+    kwargs = {
+        "att": [0.47935711, 0.44950136, 0.68474659, 0.31509901],
+        "date": "2025:258:14:42:16.000",
+        "detector": "HRC-S",
+        "dither_acq": (20, 20),
+        "dither_guide": (20, 20),
+        "man_angle": 180,
+        "n_acq": 8,
+        "n_fid": 3,
+        "n_guide": 5,
+        "obsid": 29674,
+        "sim_offset": 0,
+        "focus_offset": 0,
+        "t_ccd_acq": -8.6,
+        "t_ccd_guide": -8.6,
+        "dyn_bgd_n_faint": 2,
+        # These last two kwargs are required for Jupiter checks
+        "target_name": "ALL ABOUT JUPITER",
+        "duration": 10000,
+    }
+    aca = get_aca_catalog(**kwargs)
+    acar = aca.get_review_table()
+    acar.run_aca_review(make_html=False)
+    assert acar.messages[-1] == {"category": "info", "text": "Ran Jupiter checks"}
+
+
+def test_jupiter_not_present():
+    kwargs = KWARGS_48464.copy()
+    # This target name "accidentally has jupiter in it"
+    kwargs["target_name"] = "NO JUPITER HERE"
+    kwargs["duration"] = 30000
+    kwargs["t_ccd_acq"] = -10
+    kwargs["t_ccd_guide"] = -10
+    aca = get_aca_catalog(**kwargs)
+    acar = aca.get_review_table()
+    acar.run_aca_review(make_html=False)
+    # Confirm one of the messages is {'category': 'critical', 'text': 'No Jupiter position found'}
+    assert any(
+        msg == {"category": "critical", "text": "No Jupiter position found"}
+        for msg in acar.messages
+    )
+
+
 def test_t_ccd_effective_message():
     """Test printing a message about effective guide and/or acq CCD temperature
     when it is different from the predicted temperature."""

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -75,7 +75,11 @@ def test_jupiter_not_present():
     acar.run_aca_review(make_html=False)
     # Confirm one of the messages is {'category': 'critical', 'text': 'No Jupiter position found'}
     assert any(
-        msg == {"category": "critical", "text": "No Jupiter position found"}
+        msg
+        == {
+            "category": "critical",
+            "text": "Jupiter not on CCD, expected for target 'NO JUPITER HERE'",
+        }
         for msg in acar.messages
     )
 

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -60,7 +60,10 @@ def test_jupiter_present():
     aca = get_aca_catalog(**kwargs)
     acar = aca.get_review_table()
     acar.run_aca_review(make_html=False)
-    assert acar.messages[-1] == {"category": "info", "text": "Ran Jupiter checks"}
+    assert acar.messages[-1] == {
+        "category": "info",
+        "text": "Jupiter mag <= -2.0. Ran Partial OBO Mitigation checks.",
+    }
 
 
 def test_jupiter_not_present():

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -73,11 +73,11 @@ def test_jupiter_not_present():
     aca = get_aca_catalog(**kwargs)
     acar = aca.get_review_table()
     acar.run_aca_review(make_html=False)
-    # Confirm one of the messages is {'category': 'critical', 'text': 'No Jupiter position found'}
+    # Confirm one of the messages is {'category': 'warning', 'text': 'No Jupiter position found'}
     assert any(
         msg
         == {
-            "category": "critical",
+            "category": "warning",
             "text": "Jupiter not on CCD, expected for target 'NO JUPITER HERE'",
         }
         for msg in acar.messages


### PR DESCRIPTION
## Description

Run Jupiter checks.

This PR adds three new sparkles checks:

- check_jupiter_acq_spoilers
- check_jupiter_track_spoilers
- check_jupiter_distribution

And a "wrapper" check
- check_run_jupiter_checks

check_jupiter_acq_spoilers: This confirms that no acquisition search box contains the columns within 15 pixels of the Jupiter position at acquisition.  (TBD - add maneuver error to check?)

check_jupiter_track_spoilers: This confirms that no fid light or guide star is within 15 pixels in column of Jupiter during the duration of the observation.

check_jupiter_distribution: This confirms that there are always at least two guide stars on the "side" of the CCD opposite Jupiter.

check_run_jupiter_checks: This runs the above three checks if Jupiter is on the CCD and adds an info message that the Jupiter checks have run.  If Jupiter is not on the CCD during the observation but is in the target name, this adds a critical warning (not 100% an ACA issue, but if Jupiter was supposed to be there, something is wrong with the attitude).

For speed, the Jupiter checks are only run if Jupiter is in the target name.  These methods use proseco.jupiter code as applicable.

## Requires

proseco: [Consider jupiter in selection](https://github.com/sot/proseco/pull/408)

the proseco PR requires the cheta stk PR https://github.com/sot/cheta/pull/257 so both need to be available for unit testing sparkles.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-latest) flame:sparkles jean$ python -c "import cheta; print(cheta.__version__); import proseco; print(proseco.__version__);"
4.64.1.dev14+g90860f2
5.16.3.dev45+g4c3d548
(ska3-latest) flame:sparkles jean$ git rev-parse HEAD
2bab011118877741da76661e00f6d7899aeac5ec
(ska3-latest) flame:sparkles jean$ pytest
==================================================================================== test session starts ====================================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: socket-0.7.0, anyio-4.7.0, timeout-2.3.1
collected 128 items                                                                                                                                                                         

sparkles/tests/test_checks.py ..................................................................................................                                                      [ 76%]
sparkles/tests/test_find_er_catalog.py .....                                                                                                                                          [ 80%]
sparkles/tests/test_review.py .....................                                                                                                                                   [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                                                                     [100%]

===================================================================================== warnings summary ======================================================================================
sparkles/sparkles/tests/test_review.py::test_jupiter_not_present
sparkles/sparkles/tests/test_review.py::test_jupiter_not_present
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 128 passed, 2 warnings in 36.12
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
New unit tests.
