### PR TITLE
Fix a test for a proseco fix and update a warning print for future numpy 2 compat

### DIFF
--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -273,7 +273,7 @@ def check_guide_geometry(acar: ACACheckTable) -> list[Message]:
                 break
         else:
             # Every distance was too small, issue a warning.
-            cat_idxs = [idx + 1 for idx in idxs]
+            cat_idxs = [int(idx + 1) for idx in idxs]
             msg = f'Guide indexes {cat_idxs} clustered within {min_dist}" radius'
 
             if acar.man_angle_next > CREEP_AWAY_THRESHOLD:

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -939,6 +939,11 @@ def test_bad_star_set(aca_review_table):
     check_catalog(acar)
     assert acar.messages == [
         {
+            "text": f"Guide star {bad_id} does not meet guide candidate criteria",
+            "category": "critical",
+            "idx": 5,
+        },
+        {
             "text": f"Star {bad_id} is in proseco bad star set",
             "category": "critical",
             "idx": 5,


### PR DESCRIPTION
## Description

Two small updates:

1) Updates test reference data in the test_bad_star_set test for latent bug fix found in numpy 2 testing . There should always have been the candidate criteria critical warning in the warns for that test.

2) Cast the star catalog index to an int in the check_guide_geometry.  This is only used in the warning printing.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->

## Requires 
- https://github.com/sot/proseco/pull/412 if ska is with numpy < 2

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac ska3 latest "pre hope"
```
(ska3-latest) flame:sparkles jean$ export PYTHONPATH=/Users/jean/git/proseco
(ska3-latest) flame:sparkles jean$ python -c "import proseco; print(proseco.__version__)"
5.17.1.dev1+ga6b51fa
(ska3-latest) flame:sparkles jean$ git rev-parse HEAD
b8acee57652d92e71bce37be38f89be769f6498d
(ska3-latest) flame:sparkles jean$ pytest
============================================================= test session starts =============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: socket-0.7.0, anyio-4.7.0, timeout-2.3.1
collected 128 items                                                                                                                           

sparkles/tests/test_checks.py ..................................................................................................        [ 76%]
sparkles/tests/test_find_er_catalog.py .....                                                                                            [ 80%]
sparkles/tests/test_review.py .....................                                                                                     [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                       [100%]

============================================================== warnings summary ===============================================================
sparkles/sparkles/tests/test_review.py::test_jupiter_not_present
sparkles/sparkles/tests/test_review.py::test_jupiter_not_present
  /Users/jean/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================================== 128 passed, 2 warnings in 36.95
```

- [x] Linux ska3-flight plus proseco with https://github.com/sot/proseco/pull/412
```
ska3-jeanconn-kady> export PYTHONPATH=/home/jeanconn/git/proseco
ska3-jeanconn-kady> python -c "import proseco; print(proseco.__version__)"
5.17.1.dev2+gb7c8104
ska3-jeanconn-kady> pytest
=========================================================== test session starts ===========================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 128 items                                                                                                                       

sparkles/tests/test_checks.py ..................................................................................................    [ 76%]
sparkles/tests/test_find_er_catalog.py .....                                                                                        [ 80%]
sparkles/tests/test_review.py .....................                                                                                 [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                   [100%]

============================================================ warnings summary =============================================================
sparkles/sparkles/tests/test_review.py::test_jupiter_present
sparkles/sparkles/tests/test_review.py::test_jupiter_not_present
sparkles/sparkles/tests/test_review.py::test_jupiter_not_present
  /proj/sot/ska3/flight/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================== 128 passed, 3 warnings in 110.29s (0:01:50) ===============================================
ska3-jeanconn-kady> git rev-parse HEAD
b8acee57652d92e71bce37be38f89be769f6498d
```
- [x] OSX with recent hope plus proseco PR
```
(ska3-flight-2026.0rc4) flame:sparkles jean$ git rev-parse HEAD
b8acee57652d92e71bce37be38f89be769f6498d
(ska3-flight-2026.0rc4) flame:sparkles jean$ python -c "import proseco; print(proseco.__version__)"
5.17.1.dev1+ga6b51fa9c
(ska3-flight-2026.0rc4) flame:sparkles jean$ pytest 
================================================== test session starts ===================================================
platform darwin -- Python 3.13.10, pytest-9.0.1, pluggy-1.6.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.12.0, timeout-2.4.0
collected 128 items                                                                                                      

sparkles/tests/test_checks.py .................................................................................... [ 65%]
..............                                                                                                     [ 76%]
sparkles/tests/test_find_er_catalog.py .....                                                                       [ 80%]
sparkles/tests/test_review.py .....................                                                                [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                  [100%]

==================================================== warnings summary ====================================================
sparkles/sparkles/tests/test_checks.py: 108 warnings
sparkles/sparkles/tests/test_find_er_catalog.py: 10 warnings
sparkles/sparkles/tests/test_review.py: 91 warnings
sparkles/sparkles/tests/test_yoshi.py: 2 warnings
  /Users/jean/miniforge3/envs/ska3-flight-2026.0rc4/lib/python3.13/site-packages/proseco/guide.py:964: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    bad = np.in1d(cand_guides["id"], list(ACA.bad_star_set))

sparkles/sparkles/tests/test_checks.py::test_check_jupiter_acq_spoilers_fail[ACAReviewTable]
sparkles/sparkles/tests/test_checks.py::test_check_jupiter_acq_spoilers_fail[ACACheckTable]
sparkles/sparkles/tests/test_checks.py::test_check_jupiter_acq_spoilers_none[ACAReviewTable]
sparkles/sparkles/tests/test_checks.py::test_check_jupiter_acq_spoilers_none[ACACheckTable]
sparkles/sparkles/tests/test_review.py::test_jupiter_present
sparkles/sparkles/tests/test_review.py::test_jupiter_not_present
  /Users/jean/git/sparkles/sparkles/checks.py:152: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    ok = np.in1d(acar["type"], ("BOT", "ACQ"))

sparkles/sparkles/tests/test_checks.py: 10 warnings
sparkles/sparkles/tests/test_review.py: 2 warnings
  /Users/jean/git/sparkles/sparkles/checks.py:194: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    ok = np.in1d(acar["type"], ("GUI", "BOT", "FID"))

sparkles/sparkles/tests/test_checks.py::test_check_jupiter_distribution[-300-ACAReviewTable]
sparkles/sparkles/tests/test_checks.py::test_check_jupiter_distribution[-300-ACACheckTable]
sparkles/sparkles/tests/test_checks.py::test_check_jupiter_distribution[300-ACAReviewTable]
sparkles/sparkles/tests/test_checks.py::test_check_jupiter_distribution[300-ACACheckTable]
sparkles/sparkles/tests/test_checks.py::test_check_jupiter_distribution_cross[ACAReviewTable]
sparkles/sparkles/tests/test_checks.py::test_check_jupiter_distribution_cross[ACACheckTable]
sparkles/sparkles/tests/test_review.py::test_jupiter_present
sparkles/sparkles/tests/test_review.py::test_jupiter_not_present
  /Users/jean/git/sparkles/sparkles/checks.py:228: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    ok = np.in1d(acar["type"], ("GUI", "BOT"))

sparkles/sparkles/tests/test_checks.py: 13 warnings
sparkles/sparkles/tests/test_find_er_catalog.py: 5 warnings
sparkles/sparkles/tests/test_review.py: 68 warnings
sparkles/sparkles/tests/test_yoshi.py: 1 warning
  /Users/jean/git/sparkles/sparkles/checks.py:49: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    ok = np.in1d(acar["type"], ("GUI", "BOT", "FID", "MON"))

sparkles/sparkles/tests/test_checks.py: 23 warnings
sparkles/sparkles/tests/test_find_er_catalog.py: 5 warnings
sparkles/sparkles/tests/test_review.py: 68 warnings
sparkles/sparkles/tests/test_yoshi.py: 1 warning
  /Users/jean/git/sparkles/sparkles/checks.py:252: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    ok = np.in1d(acar["type"], ("GUI", "BOT"))

sparkles/sparkles/tests/test_checks.py::test_include_exclude[ACAReviewTable]
sparkles/sparkles/tests/test_checks.py::test_include_exclude[ACACheckTable]
sparkles/sparkles/tests/test_review.py::test_roll_options_with_include_ids
  /Users/jean/miniforge3/envs/ska3-flight-2026.0rc4/lib/python3.13/site-packages/proseco/acq.py:856: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    ok = np.in1d(cand_acqs["id"], self.include_ids)

sparkles/sparkles/tests/test_review.py: 18 warnings
  /Users/jean/git/sparkles/sparkles/roll_optimize.py:164: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    overlap = np.in1d(self.guides["id"], acqs["id"])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 128 passed, 442 warnings in 38.10s ===========================================
(ska3-flight-2026.0rc4) flame:sparkles jean$ 

```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
