### PR TITLE
Replace np.in1d with np.isin

### DIFF
--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -46,7 +46,7 @@ def check_guide_overlap(acar: ACACheckTable) -> list[Message]:
     Overlap is defined as within 12 pixels.
     """
     msgs = []
-    ok = np.in1d(acar["type"], ("GUI", "BOT", "FID", "MON"))
+    ok = np.isin(acar["type"], ("GUI", "BOT", "FID", "MON"))
     idxs = np.flatnonzero(ok)
     for idx1, idx2 in combinations(idxs, 2):
         entry1 = acar[idx1]
@@ -149,7 +149,7 @@ def check_jupiter_acq_spoilers(acar: ACACheckTable) -> list[Message]:
     from proseco.jupiter import get_jupiter_acq_pos
 
     msgs = []
-    ok = np.in1d(acar["type"], ("BOT", "ACQ"))
+    ok = np.isin(acar["type"], ("BOT", "ACQ"))
     acqs = acar[ok]
     pad = 15
 
@@ -191,7 +191,7 @@ def check_jupiter_track_spoilers(acar: ACACheckTable) -> list[Message]:
     from proseco.jupiter import check_spoiled_by_jupiter
 
     msgs = []
-    ok = np.in1d(acar["type"], ("GUI", "BOT", "FID"))
+    ok = np.isin(acar["type"], ("GUI", "BOT", "FID"))
     guide_and_fid = acar[ok]
     spoiled, _ = check_spoiled_by_jupiter(guide_and_fid, acar.jupiter)
     for row in guide_and_fid[spoiled]:
@@ -225,7 +225,7 @@ def check_jupiter_distribution(acar: ACACheckTable) -> list[Message]:
 
     # Check that there are at least 2 guide stars in each quadrant of the ccd
     msgs = []
-    ok = np.in1d(acar["type"], ("GUI", "BOT"))
+    ok = np.isin(acar["type"], ("GUI", "BOT"))
     if not jupiter_distribution_check(acar[ok], acar.jupiter):
         msg = (
             "Jupiter guide star distribution check failed. "
@@ -249,7 +249,7 @@ def check_guide_geometry(acar: ACACheckTable) -> list[Message]:
 
     """
     msgs = []
-    ok = np.in1d(acar["type"], ("GUI", "BOT"))
+    ok = np.isin(acar["type"], ("GUI", "BOT"))
     guide_idxs = np.flatnonzero(ok)
     n_guide = len(guide_idxs)
 

--- a/sparkles/roll_optimize.py
+++ b/sparkles/roll_optimize.py
@@ -161,7 +161,7 @@ class RollOptimizeMixin:
         acqs.meta.clear()
 
         # Mask for guide star IDs that are also in acqs
-        overlap = np.in1d(self.guides["id"], acqs["id"])
+        overlap = np.isin(self.guides["id"], acqs["id"])
         guides = Table(self.guides[cols][~overlap])
         guides.meta.clear()
         cands = vstack([acqs, guides, self.stars[cols][cand_idxs]])


### PR DESCRIPTION
## Description

Remove some warnings by replacing all uses of `np.in1d` with `np.isin`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux (tests used proseco @b7c8104 needed for test_bad_star_set and not the numpy 2 PR that fixes the warnings)
```
(ska3-flight) jgonzale sparkles $ git rev-parse HEAD
98f47b27a1066f61c51124bffe4c1a2faf421a30
(ska3-flight) jgonzale sparkles $ pytest sparkles
==================================================================== test session starts =====================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 128 items                                                                                                                                          

sparkles/tests/test_checks.py ..................................................................................................                       [ 76%]
sparkles/tests/test_find_er_catalog.py .....                                                                                                           [ 80%]
sparkles/tests/test_review.py .....................                                                                                                    [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                                      [100%]

=============================================================== 128 passed in 94.25s (0:01:34) ===============================================================
(ska3-flight) jgonzale sparkles $ conda activate ska3-flight-2026.0rc4
(ska3-flight-2026.0rc4) jgonzale sparkles $ pytest sparkles
==================================================================== test session starts =====================================================================
platform linux -- Python 3.13.10, pytest-9.0.1, pluggy-1.6.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: timeout-2.4.0, anyio-4.12.0
collected 128 items                                                                                                                                          

sparkles/tests/test_checks.py ..................................................................................................                       [ 76%]
sparkles/tests/test_find_er_catalog.py .....                                                                                                           [ 80%]
sparkles/tests/test_review.py .....................                                                                                                    [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                                      [100%]

====================================================================== warnings summary ======================================================================
sparkles/sparkles/tests/test_checks.py: 108 warnings
sparkles/sparkles/tests/test_find_er_catalog.py: 10 warnings
sparkles/sparkles/tests/test_review.py: 91 warnings
sparkles/sparkles/tests/test_yoshi.py: 2 warnings
  /proj/sot/ska/jgonzalez/git/proseco/proseco/guide.py:964: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    bad = np.in1d(cand_guides["id"], list(ACA.bad_star_set))

sparkles/sparkles/tests/test_checks.py::test_include_exclude[ACAReviewTable]
sparkles/sparkles/tests/test_checks.py::test_include_exclude[ACACheckTable]
sparkles/sparkles/tests/test_review.py::test_roll_options_with_include_ids
  /proj/sot/ska/jgonzalez/git/proseco/proseco/acq.py:856: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
    ok = np.in1d(cand_acqs["id"], self.include_ids)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================== 128 passed, 214 warnings in 85.17s (0:01:25) ========================================================

```

Independent check of unit tests by Jean
- [x] osx pre-hope 
```
(latest) flame:sparkles jean$ pytest
=============================================================== test session starts ===============================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 128 items                                                                                                                               

sparkles/tests/test_checks.py ..................................................................................................            [ 76%]
sparkles/tests/test_find_er_catalog.py .....                                                                                                [ 80%]
sparkles/tests/test_review.py .....................                                                                                         [ 96%]
sparkles/tests/test_yoshi.py ....                                                                                                           [100%]

================================================================ warnings summary =================================================================
sparkles/sparkles/tests/test_review.py::test_jupiter_not_present
sparkles/sparkles/tests/test_review.py::test_jupiter_not_present
  /Users/jean/miniforge3/envs/latest/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================== 128 passed, 2 warnings in 36.49s
```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
