### PR TITLE
Generalize handling of optically bright planets.

### DIFF
--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -67,8 +67,8 @@ from proseco.bright_object import check_for_close_planets
 
 def check_planets(acar: ACACheckTable) -> list[Message]:
     import astropy.units as u
-    from cxotime import CxoTime
     from chandra_aca.planets import BRIGHT_PLANET_LIST
+    from cxotime import CxoTime
 
     msgs = []
     duration = acar.duration if acar.duration is not None else 0.0
@@ -105,7 +105,8 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
             if not np.all(mag_states["label"] == "no action"):
                 msgs += [
                     Message(
-                        "critical", f"{planet.capitalize()} within 2 deg but not on CCD."
+                        "critical",
+                        f"{planet.capitalize()} within 2 deg but not on CCD.",
                     )
                 ]
             continue
@@ -161,14 +162,16 @@ def check_run_obo_checks(
         msgs += check_full_obo_distribution(acar, planet_pos)
         msgs += [
             Message(
-                "info", f"{planet.capitalize()} mag <= -2.9. Ran Full OBO Mitigation checks."
+                "info",
+                f"{planet.capitalize()} mag <= -2.9. Ran Full OBO Mitigation checks.",
             )
         ]
     else:
         msgs += check_partial_obo_distribution(acar, planet_pos)
         msgs += [
             Message(
-                "info", f"{planet.capitalize()} mag <= -2.0. Ran Partial OBO Mitigation checks."
+                "info",
+                f"{planet.capitalize()} mag <= -2.0. Ran Partial OBO Mitigation checks.",
             )
         ]
     return msgs

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -164,7 +164,9 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
     return msgs
 
 
-def check_obo_spoilers(acar: ACACheckTable, planet=None, planet_pos=None) -> list[Message]:
+def check_obo_spoilers(
+    acar: ACACheckTable, planet=None, planet_pos=None
+) -> list[Message]:
     msgs = []
     msgs += check_obo_acq_spoilers(acar, planet, planet_pos)
     msgs += check_obo_track_spoilers(acar, planet, planet_pos)

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -284,7 +284,9 @@ def check_obo_track_spoilers(
     guide_and_fid = acar[ok]
     spoiled, _ = check_spoiled_by_bright_object(guide_and_fid, planet_pos)
     for row in guide_and_fid[spoiled]:
-        msg = f"{planet.capitalize()} spoils tracked star idx {row['idx']} id {row['id']}"
+        msg = (
+            f"{planet.capitalize()} spoils tracked star idx {row['idx']} id {row['id']}"
+        )
         msgs += [Message("critical", msg, idx=row["idx"])]
     return msgs
 

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -284,7 +284,7 @@ def check_obo_track_spoilers(
     guide_and_fid = acar[ok]
     spoiled, _ = check_spoiled_by_bright_object(guide_and_fid, planet_pos)
     for row in guide_and_fid[spoiled]:
-        msg = f"{planet.capitalize()}. spoils tracked star idx {row['idx']} id {row['id']}"
+        msg = f"{planet.capitalize()} spoils tracked star idx {row['idx']} id {row['id']}"
         msgs += [Message("critical", msg, idx=row["idx"])]
     return msgs
 

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -67,6 +67,7 @@ from proseco.bright_object import check_for_close_planets
 
 def check_planets(acar: ACACheckTable) -> list[Message]:
     import astropy.units as u
+
     msgs = []
     duration = acar.duration if acar.duration is not None else 0.0
     planets = check_for_close_planets(acar.date, duration, acar.att)
@@ -75,12 +76,14 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
         if len(planets[planet]) == 0:
             continue
 
-        from chandra_aca.planets import (get_planet_chandra_ccd_position,
-                                                get_planet_mag_states)
+        from chandra_aca.planets import (
+            get_planet_chandra_ccd_position,
+            get_planet_mag_states,
+        )
+
         mag_states = get_planet_mag_states(
-            planet,
-            acar.date,
-            acar.date + duration * u.s)
+            planet, acar.date, acar.date + duration * u.s
+        )
         # min/brightest mag state
         min_state_idx = np.argmin(mag_states["mag_start"])
         min_state = mag_states[min_state_idx]
@@ -97,48 +100,69 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
 
         # If planet is within 2 degrees but not on CCD, that's a critical
         if len(planet_pos) == 0:
-            msgs += [Message("critical",
-                                f"{planet.capitalize()} within 2 deg but not on CCD.")]
+            msgs += [
+                Message(
+                    "critical", f"{planet.capitalize()} within 2 deg but not on CCD."
+                )
+            ]
             continue
 
         # If this is just too bright that is also critical
         if min_state["label"] == "obo too bright":
-            msgs += [Message("critical",
-                                f"{planet.capitalize()} too bright.")]
+            msgs += [Message("critical", f"{planet.capitalize()} too bright.")]
             continue
 
         # If there is any kind of bright object but it isn't the target, warn
-        if min_state["label"] in ["partial mitigation", "full mitigation", "instrument notify"] and planet not in acar.target_name.lower():
-            msgs += [Message("warning",
-                             f"Bright object alert: {planet.title()} on CCD but not in target name\n"
-                            )]
+        if (
+            min_state["label"]
+            in ["partial mitigation", "full mitigation", "instrument notify"]
+            and planet not in acar.target_name.lower()
+        ):
+            msgs += [
+                Message(
+                    "warning",
+                    f"Bright object alert: {planet.title()} on CCD but not in target name\n",
+                )
+            ]
 
         # And skip the rest of the checks unless in a mitigation state
         if min_state["label"] in ["partial mitigation", "full mitigation"]:
             mitigation = "full" if min_state["label"].startswith("full") else "partial"
-            msgs += checks.check_run_obo_checks(acar, mitigation=mitigation,
-                                                planet=planet,
-                                                planet_pos=planet_pos,
-                                                )
+            msgs += check_run_obo_checks(
+                acar,
+                mitigation=mitigation,
+                planet=planet,
+                planet_pos=planet_pos,
+            )
     return msgs
 
 
-
-def check_run_obo_checks(acar: ACACheckTable, mitigation="partial",
-                         planet=None, planet_pos=None) -> list[Message]:
+def check_run_obo_checks(
+    acar: ACACheckTable, mitigation="partial", planet=None, planet_pos=None
+) -> list[Message]:
     msgs = []
     msgs += check_obo_acq_spoilers(acar, planet, planet_pos)
     msgs += check_obo_track_spoilers(acar, planet, planet_pos)
     if mitigation == "full":
         msgs += check_full_obo_distribution(acar, planet_pos)
-        msgs += [Message("info", "Bright object mag <= -2.9. Ran Full OBO Mitigation checks.")]
+        msgs += [
+            Message(
+                "info", "Bright object mag <= -2.9. Ran Full OBO Mitigation checks."
+            )
+        ]
     else:
         msgs += check_partial_obo_distribution(acar, planet_pos)
-        msgs += [Message("info", "Bright object mag <= -2.0. Ran Partial OBO Mitigation checks.")]
+        msgs += [
+            Message(
+                "info", "Bright object mag <= -2.0. Ran Partial OBO Mitigation checks."
+            )
+        ]
     return msgs
 
 
-def check_obo_acq_spoilers(acar: ACACheckTable, planet=None, planet_pos=None) -> list[Message]:
+def check_obo_acq_spoilers(
+    acar: ACACheckTable, planet=None, planet_pos=None
+) -> list[Message]:
     """
     Check for columns spoiled by Jupiter in acquisition boxes.
 
@@ -181,7 +205,9 @@ def check_obo_acq_spoilers(acar: ACACheckTable, planet=None, planet_pos=None) ->
     return msgs
 
 
-def check_obo_track_spoilers(acar: ACACheckTable, planet=None, planet_pos=None) -> list[Message]:
+def check_obo_track_spoilers(
+    acar: ACACheckTable, planet=None, planet_pos=None
+) -> list[Message]:
     """
     Check for Jupiter spoiling stars or fids.
 
@@ -210,7 +236,9 @@ def check_obo_track_spoilers(acar: ACACheckTable, planet=None, planet_pos=None) 
     return msgs
 
 
-def check_partial_obo_distribution(acar: ACACheckTable, planet_pos=None) -> list[Message]:
+def check_partial_obo_distribution(
+    acar: ACACheckTable, planet_pos=None
+) -> list[Message]:
     """
     Check for guide star distribution for Jupiter fields.
 
@@ -245,9 +273,9 @@ def check_partial_obo_distribution(acar: ACACheckTable, planet_pos=None) -> list
     return msgs
 
 
-def check_full_obo_distribution(acar: ACACheckTable, planet_pos=None,
-                                dither=20, bright_object_size = 4.5) -> list[Message]:
-
+def check_full_obo_distribution(
+    acar: ACACheckTable, planet_pos=None, dither=20, bright_object_size=4.5
+) -> list[Message]:
     # This function is in sparkles instead of proseco because we do not expect
     # to actually need full OBO checks in star selection.
     msgs = []
@@ -262,20 +290,22 @@ def check_full_obo_distribution(acar: ACACheckTable, planet_pos=None,
     # It looks like jupiter ang diam goes from 30 to 45 arcsec
     # so use 45 / 2 = 22.5 arcsec radius -> 4.5 pixels
     # and add a 4 pixel dither pad corresponding to the 20 arcsec HRC pattern
-    dither_pix = dither / 5. # pixels
+    dither_pix = dither / 5.0  # pixels
     sign_max = np.sign(np.max(planet_pos["row"] + bright_object_size + dither_pix))
     sign_min = np.sign(np.min(planet_pos["row"] - bright_object_size - dither_pix))
-    five_guide_opposite = (np.count_nonzero(np.sign(guide_stars["row"]) != sign_max) >= 5) and (
-        np.count_nonzero(np.sign(guide_stars["row"]) != sign_min) >= 5
-    )
+    five_guide_opposite = (
+        np.count_nonzero(np.sign(guide_stars["row"]) != sign_max) >= 5
+    ) and (np.count_nonzero(np.sign(guide_stars["row"]) != sign_min) >= 5)
 
     two_fids_opposite = (np.count_nonzero(np.sign(fids["row"]) != sign_max) >= 2) and (
-        np.count_nonzero(np.sign(fids["row"]) != sign_min) >= 2)
+        np.count_nonzero(np.sign(fids["row"]) != sign_min) >= 2
+    )
 
     # obo never within 2 arcmin of ccd boundary row=0
     # 2 arcmin = 120 arcsec = 24 pixels
-    obo_not_near_boundary = (np.all(np.abs(planet_pos["row"] + bright_object_size + dither_pix) > 24) and
-                         np.all(np.abs(planet_pos["row"] - bright_object_size - dither_pix) > 24))
+    obo_not_near_boundary = np.all(
+        np.abs(planet_pos["row"] + bright_object_size + dither_pix) > 24
+    ) and np.all(np.abs(planet_pos["row"] - bright_object_size - dither_pix) > 24)
     # Has 6 guide stars
     has_6_guides = np.isin(acar["type"], ("GUI", "BOT")).sum() >= 6
 
@@ -284,24 +314,31 @@ def check_full_obo_distribution(acar: ACACheckTable, planet_pos=None,
 
     if not five_guide_opposite:
         overall_check = False
-        msgs += [Message("critical",
-            "Need 5 guide stars on each side of CCD opposite bright object.")]
+        msgs += [
+            Message(
+                "critical",
+                "Need 5 guide stars on each side of CCD opposite bright object.",
+            )
+        ]
     if not two_fids_opposite:
         overall_check = False
-        msgs += [Message("critical",
-            "Need 2 fid lights on each side of CCD opposite bright object.")]
+        msgs += [
+            Message(
+                "critical",
+                "Need 2 fid lights on each side of CCD opposite bright object.",
+            )
+        ]
     if not obo_not_near_boundary:
         overall_check = False
-        msgs += [Message("critical",
-            "Bright object tracks too close to CCD boundary row=0.")]
+        msgs += [
+            Message("critical", "Bright object tracks too close to CCD boundary row=0.")
+        ]
     if not has_6_guides:
         overall_check = False
-        msgs += [Message("critical",
-            "Need at least 6 guide stars in the catalog.")]
+        msgs += [Message("critical", "Need at least 6 guide stars in the catalog.")]
     if np.isin(acar["type"], "FID").any() and not has_2_fids:
         overall_check = False
-        msgs += [Message("critical",
-            "Need at least 2 fid lights in the catalog.")]
+        msgs += [Message("critical", "Need at least 2 fid lights in the catalog.")]
 
     if not overall_check:
         msgs += [Message("critical", "Full mitigation OBO checks failed.")]

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -119,14 +119,18 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
             continue
 
         # If there is any kind of bright object but it isn't the target, warn
-        if (
-            min_state["label"]
-            in ["partial mitigation", "full mitigation", "instrument notify"]
-            and planet not in acar.target_name.lower()
-        ):
+        if planet not in acar.target_name.lower():
+            if min_state["label"] in [
+                "partial mitigation",
+                "full mitigation",
+                "instrument_notify",
+            ]:
+                warning_level = "warning"
+            elif min_state["label"] == "no action":
+                warning_level = "info"
             msgs += [
                 Message(
-                    "warning",
+                    warning_level,
                     f"Bright object alert: {planet.title()} on CCD but not in target name\n",
                 )
             ]

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -62,73 +62,83 @@ def check_guide_overlap(acar: ACACheckTable) -> list[Message]:
     return msgs
 
 
-def check_run_jupiter_checks(acar: ACACheckTable) -> list[Message]:
-    """
-    Run jupiter checks.
+from proseco.bright_object import check_for_close_planets
 
-    This is a wrapper to run the jupiter checks.  It first checks if the date
-    is excluded from jupiter checks.  If not, it gets the jupiter position
-    and then runs the individual jupiter checks.
 
-    Parameters
-    ----------
-    acar : ACACheckTable
-        The ACA review table to check.
-
-    Returns
-    -------
-    list of Message
-        List of messages from the jupiter checks.
-    """
+def check_planets(acar: ACACheckTable) -> list[Message]:
+    import astropy.units as u
     msgs = []
-    if "jupiter" not in acar.target_name.lower():
-        return msgs
+    duration = acar.duration if acar.duration is not None else 0.0
+    planets = check_for_close_planets(acar.date, duration, acar.att)
+    for planet in planets:
+        # If the table is empty, just skip
+        if len(planets[planet]) == 0:
+            continue
 
-    from proseco import jupiter
+        from chandra_aca.planets import (get_planet_chandra_ccd_position,
+                                                get_planet_mag_states)
+        mag_states = get_planet_mag_states(
+            planet,
+            acar.date,
+            acar.date + duration * u.s)
+        # min/brightest mag state
+        min_state_idx = np.argmin(mag_states["mag_start"])
+        min_state = mag_states[min_state_idx]
 
-    # First check for exclude dates when Jupiter is fainter than the Optically Bright
-    # Object limit of -2.0 mag.
-    if jupiter.date_is_excluded(acar.date):
-        msgs += [
-            Message("info", "Jupiter fainter than -2.0 mag - no Jupiter checks run")
-        ]
-        return msgs
+        if np.all(mag_states["label"] == "no action"):
+            continue
 
-    msgs += check_jupiter_on_ccd(acar)
-    msgs += check_jupiter_acq_spoilers(acar)
-    msgs += check_jupiter_track_spoilers(acar)
-    msgs += check_jupiter_distribution(acar)
+        planet_pos = get_planet_chandra_ccd_position(
+            planet,
+            acar.date,
+            acar.duration,
+            acar.att,
+        )
 
-    msgs += [Message("info", "Jupiter mag <= -2.0. Ran Partial OBO Mitigation checks.")]
+        # If planet is within 2 degrees but not on CCD, that's a critical
+        if len(planet_pos) == 0:
+            msgs += [Message("critical",
+                                f"{planet.capitalize()} within 2 deg but not on CCD.")]
+            continue
+
+        # If this is just too bright that is also critical
+        if min_state["label"] == "obo too bright":
+            msgs += [Message("critical",
+                                f"{planet.capitalize()} too bright.")]
+            continue
+
+        # If there is any kind of bright object but it isn't the target, warn
+        if min_state["label"] in ["partial mitigation", "full mitigation", "instrument notify"] and planet not in acar.target_name.lower():
+            msgs += [Message("warning",
+                             f"Bright object alert: {planet.title()} on CCD but not in target name\n"
+                            )]
+
+        # And skip the rest of the checks unless in a mitigation state
+        if min_state["label"] in ["partial mitigation", "full mitigation"]:
+            mitigation = "full" if min_state["label"].startswith("full") else "partial"
+            msgs += checks.check_run_obo_checks(acar, mitigation=mitigation,
+                                                planet=planet,
+                                                planet_pos=planet_pos,
+                                                )
     return msgs
 
 
-def check_jupiter_on_ccd(acar: ACACheckTable) -> list[Message]:
-    """
-    Check if Jupiter is on the CCD.
 
-    Parameters
-    ----------
-    acar : ACACheckTable
-        The ACA review table to check.
-
-    Returns
-    -------
-    list of Message
-        List of messages from the jupiter on CCD check.
-    """
+def check_run_obo_checks(acar: ACACheckTable, mitigation="partial",
+                         planet=None, planet_pos=None) -> list[Message]:
     msgs = []
-    if len(acar.jupiter) == 0:
-        msgs += [
-            Message(
-                "warning",
-                f"Jupiter not on CCD, expected for target '{acar.target_name}'",
-            )
-        ]
+    msgs += check_obo_acq_spoilers(acar, planet, planet_pos)
+    msgs += check_obo_track_spoilers(acar, planet, planet_pos)
+    if mitigation == "full":
+        msgs += check_full_obo_distribution(acar, planet_pos)
+        msgs += [Message("info", "Bright object mag <= -2.9. Ran Full OBO Mitigation checks.")]
+    else:
+        msgs += check_partial_obo_distribution(acar, planet_pos)
+        msgs += [Message("info", "Bright object mag <= -2.0. Ran Partial OBO Mitigation checks.")]
     return msgs
 
 
-def check_jupiter_acq_spoilers(acar: ACACheckTable) -> list[Message]:
+def check_obo_acq_spoilers(acar: ACACheckTable, planet=None, planet_pos=None) -> list[Message]:
     """
     Check for columns spoiled by Jupiter in acquisition boxes.
 
@@ -146,14 +156,14 @@ def check_jupiter_acq_spoilers(acar: ACACheckTable) -> list[Message]:
     list of Message
         List of messages from the jupiter acquisition box check.
     """
-    from proseco.jupiter import get_jupiter_acq_pos
+    from proseco.bright_object import get_bright_object_acq_pos
 
     msgs = []
     ok = np.isin(acar["type"], ("BOT", "ACQ"))
     acqs = acar[ok]
     pad = 15
 
-    _, jcol = get_jupiter_acq_pos(acar.date, acar.jupiter)
+    _, jcol = get_bright_object_acq_pos(acar.date, planet_pos)
     if jcol is None:
         return []
 
@@ -164,14 +174,14 @@ def check_jupiter_acq_spoilers(acar: ACACheckTable) -> list[Message]:
         in_box = (jcol + pad >= col_min) & (jcol - pad <= col_max)
         if np.any(in_box):
             msg = (
-                f"Jupiter column in acquisition box idx {entry['idx']} id {entry['id']}"
+                f"{planet} column in acquisition box idx {entry['idx']} id {entry['id']}"
                 f" row {entry['row']:.1f} col {entry['col']:.1f}"
             )
             msgs += [Message("critical", msg, idx=entry["idx"])]
     return msgs
 
 
-def check_jupiter_track_spoilers(acar: ACACheckTable) -> list[Message]:
+def check_obo_track_spoilers(acar: ACACheckTable, planet=None, planet_pos=None) -> list[Message]:
     """
     Check for Jupiter spoiling stars or fids.
 
@@ -188,28 +198,28 @@ def check_jupiter_track_spoilers(acar: ACACheckTable) -> list[Message]:
     list of Message
         List of messages from the jupiter tracked star check.
     """
-    from proseco.jupiter import check_spoiled_by_jupiter
+    from proseco.bright_object import check_spoiled_by_bright_object
 
     msgs = []
     ok = np.isin(acar["type"], ("GUI", "BOT", "FID"))
     guide_and_fid = acar[ok]
-    spoiled, _ = check_spoiled_by_jupiter(guide_and_fid, acar.jupiter)
+    spoiled, _ = check_spoiled_by_bright_object(guide_and_fid, planet_pos)
     for row in guide_and_fid[spoiled]:
-        msg = f"Jupiter spoils tracked star idx {row['idx']} id {row['id']}"
+        msg = f"{planet} spoils tracked star idx {row['idx']} id {row['id']}"
         msgs += [Message("critical", msg, idx=row["idx"])]
     return msgs
 
 
-def check_jupiter_distribution(acar: ACACheckTable) -> list[Message]:
+def check_partial_obo_distribution(acar: ACACheckTable, planet_pos=None) -> list[Message]:
     """
     Check for guide star distribution for Jupiter fields.
 
     The guideline requires at least 2 guide stars on the CCD half opposite
-    Jupiter, one side of the CCD is positive in row and the other negative.
-    If the padded Jupiter crosses the row=0 line during the observation
+    the bright object, one side of the CCD is positive in row and the other negative.
+    If the padded bright object crosses the row=0 line during the observation
     then at least 2 guide stars are required on each side.
 
-    This uses proseco.jupiter.jupiter_distribution_check.
+    This uses proseco.bright_object.bright_object_distribution_check.
 
     Parameters
     ----------
@@ -221,17 +231,81 @@ def check_jupiter_distribution(acar: ACACheckTable) -> list[Message]:
     list of Message
         List of messages from the jupiter guide star distribution check.
     """
-    from proseco.jupiter import jupiter_distribution_check
+    from proseco.bright_object import bright_object_distribution_check
 
     # Check that there are at least 2 guide stars in each quadrant of the ccd
     msgs = []
     ok = np.isin(acar["type"], ("GUI", "BOT"))
-    if not jupiter_distribution_check(acar[ok], acar.jupiter):
+    if not bright_object_distribution_check(acar[ok], planet_pos):
         msg = (
-            "Jupiter guide star distribution check failed. "
-            "Need 2 guide stars always opposite Jupiter."
+            "Partial OBO guide star distribution check failed. "
+            "Need 2 guide stars always opposite bright object."
         )
         msgs += [Message("critical", msg)]
+    return msgs
+
+
+def check_full_obo_distribution(acar: ACACheckTable, planet_pos=None,
+                                dither=20, bright_object_size = 4.5) -> list[Message]:
+
+    # This function is in sparkles instead of proseco because we do not expect
+    # to actually need full OBO checks in star selection.
+    msgs = []
+    if planet_pos is None or len(planet_pos) == 0:
+        return msgs
+
+    overall_check = True
+
+    guide_stars = acar[np.isin(acar["type"], ("GUI", "BOT"))]
+    fids = acar[np.isin(acar["type"], ("FID"))]
+
+    # It looks like jupiter ang diam goes from 30 to 45 arcsec
+    # so use 45 / 2 = 22.5 arcsec radius -> 4.5 pixels
+    # and add a 4 pixel dither pad corresponding to the 20 arcsec HRC pattern
+    dither_pix = dither / 5. # pixels
+    sign_max = np.sign(np.max(planet_pos["row"] + bright_object_size + dither_pix))
+    sign_min = np.sign(np.min(planet_pos["row"] - bright_object_size - dither_pix))
+    five_guide_opposite = (np.count_nonzero(np.sign(guide_stars["row"]) != sign_max) >= 5) and (
+        np.count_nonzero(np.sign(guide_stars["row"]) != sign_min) >= 5
+    )
+
+    two_fids_opposite = (np.count_nonzero(np.sign(fids["row"]) != sign_max) >= 2) and (
+        np.count_nonzero(np.sign(fids["row"]) != sign_min) >= 2)
+
+    # obo never within 2 arcmin of ccd boundary row=0
+    # 2 arcmin = 120 arcsec = 24 pixels
+    obo_not_near_boundary = (np.all(np.abs(planet_pos["row"] + bright_object_size + dither_pix) > 24) and
+                         np.all(np.abs(planet_pos["row"] - bright_object_size - dither_pix) > 24))
+    # Has 6 guide stars
+    has_6_guides = np.isin(acar["type"], ("GUI", "BOT")).sum() >= 6
+
+    # Has two fid lights
+    has_2_fids = np.isin(acar["type"], ("FID")).sum() >= 2
+
+    if not five_guide_opposite:
+        overall_check = False
+        msgs += [Message("critical",
+            "Need 5 guide stars on each side of CCD opposite bright object.")]
+    if not two_fids_opposite:
+        overall_check = False
+        msgs += [Message("critical",
+            "Need 2 fid lights on each side of CCD opposite bright object.")]
+    if not obo_not_near_boundary:
+        overall_check = False
+        msgs += [Message("critical",
+            "Bright object tracks too close to CCD boundary row=0.")]
+    if not has_6_guides:
+        overall_check = False
+        msgs += [Message("critical",
+            "Need at least 6 guide stars in the catalog.")]
+    if np.isin(acar["type"], "FID").any() and not has_2_fids:
+        overall_check = False
+        msgs += [Message("critical",
+            "Need at least 2 fid lights in the catalog.")]
+
+    if not overall_check:
+        msgs += [Message("critical", "Full mitigation OBO checks failed.")]
+
     return msgs
 
 

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -80,6 +80,8 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
 
     msgs = []
     duration = acar.duration if acar.duration is not None else 0.0
+    target_name = str(getattr(acar, "target_name", "") or "")
+    target_name_lower = target_name.lower()
     planets = check_for_close_planets(acar.date, duration, acar.att)
 
     planets_on_ccd = {}
@@ -123,7 +125,7 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
             continue
 
         # If there is any kind of bright object but it isn't the target, warn
-        if planet not in acar.target_name.lower():
+        if planet not in target_name_lower:
             if min_state["label"] in [
                 "partial mitigation",
                 "full mitigation",
@@ -154,11 +156,11 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
             )
 
     for planet in BRIGHT_PLANETS:
-        if planet.lower() in acar.target_name.lower() and planet not in planets_on_ccd:
+        if planet.lower() in target_name_lower and planet not in planets_on_ccd:
             msgs += [
                 Message(
                     "warning",
-                    f"{planet.capitalize()} in target name '{acar.target_name}' but not on CCD.",
+                    f"{planet.capitalize()} in target name '{target_name}' but not on CCD.",
                 )
             ]
     return msgs
@@ -282,7 +284,7 @@ def check_obo_track_spoilers(
     guide_and_fid = acar[ok]
     spoiled, _ = check_spoiled_by_bright_object(guide_and_fid, planet_pos)
     for row in guide_and_fid[spoiled]:
-        msg = f"{planet} spoils tracked star idx {row['idx']} id {row['id']}"
+        msg = f"{planet.capitalize()}. spoils tracked star idx {row['idx']} id {row['id']}"
         msgs += [Message("critical", msg, idx=row["idx"])]
     return msgs
 

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -67,10 +67,15 @@ from proseco.bright_object import check_for_close_planets
 
 def check_planets(acar: ACACheckTable) -> list[Message]:
     import astropy.units as u
+    from cxotime import CxoTime
+    from chandra_aca.planets import BRIGHT_PLANET_LIST
 
     msgs = []
     duration = acar.duration if acar.duration is not None else 0.0
     planets = check_for_close_planets(acar.date, duration, acar.att)
+
+    planets_on_ccd = {}
+
     for planet in planets:
         # If the table is empty, just skip
         if len(planets[planet]) == 0:
@@ -82,30 +87,30 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
         )
 
         mag_states = get_planet_mag_states(
-            planet, acar.date, acar.date + duration * u.s
+            planet, acar.date, CxoTime(acar.date) + duration * u.s
         )
         # min/brightest mag state
         min_state_idx = np.argmin(mag_states["mag_start"])
         min_state = mag_states[min_state_idx]
 
-        if np.all(mag_states["label"] == "no action"):
-            continue
-
         planet_pos = get_planet_chandra_ccd_position(
             planet,
             acar.date,
-            acar.duration,
+            duration,
             acar.att,
         )
 
         # If planet is within 2 degrees but not on CCD, that's a critical
         if len(planet_pos) == 0:
-            msgs += [
-                Message(
-                    "critical", f"{planet.capitalize()} within 2 deg but not on CCD."
-                )
-            ]
+            if not np.all(mag_states["label"] == "no action"):
+                msgs += [
+                    Message(
+                        "critical", f"{planet.capitalize()} within 2 deg but not on CCD."
+                    )
+                ]
             continue
+        else:
+            planets_on_ccd[planet] = True
 
         # If this is just too bright that is also critical
         if min_state["label"] == "obo too bright":
@@ -134,6 +139,15 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
                 planet=planet,
                 planet_pos=planet_pos,
             )
+
+    for planet in BRIGHT_PLANET_LIST:
+        if planet.lower() in acar.target_name.lower() and planet not in planets_on_ccd:
+            msgs += [
+                Message(
+                    "warning",
+                    f"{planet.capitalize()} in target name '{acar.target_name}' but not on CCD.",
+                )
+            ]
     return msgs
 
 
@@ -147,14 +161,14 @@ def check_run_obo_checks(
         msgs += check_full_obo_distribution(acar, planet_pos)
         msgs += [
             Message(
-                "info", "Bright object mag <= -2.9. Ran Full OBO Mitigation checks."
+                "info", f"{planet.capitalize()} mag <= -2.9. Ran Full OBO Mitigation checks."
             )
         ]
     else:
         msgs += check_partial_obo_distribution(acar, planet_pos)
         msgs += [
             Message(
-                "info", "Bright object mag <= -2.0. Ran Partial OBO Mitigation checks."
+                "info", f"{planet.capitalize()} mag <= -2.0. Ran Partial OBO Mitigation checks."
             )
         ]
     return msgs

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -2,10 +2,24 @@
 import functools
 from itertools import combinations
 
+import astropy.units as u
+from cxotime import CxoTime
+from chandra_aca.planets import BRIGHT_PLANETS
+from chandra_aca.planets import (
+    get_planet_chandra_ccd_position,
+    get_planet_mag_states,
+)
 import numpy as np
 import proseco.characteristics as ACA
 from chandra_aca.transform import mag_to_count_rate, snr_mag_for_t_ccd
 from proseco.core import ACACatalogTableRow, StarsTableRow
+from proseco.bright_object import (
+    get_bright_object_acq_pos,
+    check_for_close_planets,
+    check_spoiled_by_bright_object,
+    bright_object_distribution_check
+)
+
 
 from sparkles.aca_check_table import ACACheckTable
 from sparkles.messages import Message
@@ -62,13 +76,8 @@ def check_guide_overlap(acar: ACACheckTable) -> list[Message]:
     return msgs
 
 
-from proseco.bright_object import check_for_close_planets
-
-
 def check_planets(acar: ACACheckTable) -> list[Message]:
-    import astropy.units as u
-    from chandra_aca.planets import BRIGHT_PLANET_LIST
-    from cxotime import CxoTime
+    """Check for planets on the CCD and run appropriate checks."""
 
     msgs = []
     duration = acar.duration if acar.duration is not None else 0.0
@@ -80,11 +89,6 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
         # If the table is empty, just skip
         if len(planets[planet]) == 0:
             continue
-
-        from chandra_aca.planets import (
-            get_planet_chandra_ccd_position,
-            get_planet_mag_states,
-        )
 
         mag_states = get_planet_mag_states(
             planet, acar.date, CxoTime(acar.date) + duration * u.s
@@ -98,6 +102,7 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
             acar.date,
             duration,
             acar.att,
+            ephem_source="stk",
         )
 
         # If planet is within 2 degrees but not on CCD, that's a critical
@@ -135,17 +140,21 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
                 )
             ]
 
-        # And skip the rest of the checks unless in a mitigation state
+        # Run direct spoiler checks for any planet on CCD, even if the
+        # current magnitude does not require full or partial mitigation.
+        msgs += check_obo_spoilers(acar, planet=planet, planet_pos=planet_pos)
+
+        # Distribution checks apply only in explicit mitigation states.
         if min_state["label"] in ["partial mitigation", "full mitigation"]:
             mitigation = "full" if min_state["label"].startswith("full") else "partial"
-            msgs += check_run_obo_checks(
+            msgs += check_run_obo_distribution_checks(
                 acar,
                 mitigation=mitigation,
                 planet=planet,
                 planet_pos=planet_pos,
             )
 
-    for planet in BRIGHT_PLANET_LIST:
+    for planet in BRIGHT_PLANETS:
         if planet.lower() in acar.target_name.lower() and planet not in planets_on_ccd:
             msgs += [
                 Message(
@@ -156,12 +165,17 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
     return msgs
 
 
-def check_run_obo_checks(
-    acar: ACACheckTable, mitigation="partial", planet=None, planet_pos=None
-) -> list[Message]:
+def check_obo_spoilers(acar: ACACheckTable, planet=None, planet_pos=None) -> list[Message]:
     msgs = []
     msgs += check_obo_acq_spoilers(acar, planet, planet_pos)
     msgs += check_obo_track_spoilers(acar, planet, planet_pos)
+    return msgs
+
+
+def check_run_obo_distribution_checks(
+    acar: ACACheckTable, mitigation="partial", planet=None, planet_pos=None
+) -> list[Message]:
+    msgs = []
     if mitigation == "full":
         msgs += check_full_obo_distribution(acar, planet_pos)
         msgs += [
@@ -178,6 +192,16 @@ def check_run_obo_checks(
                 f"{planet.capitalize()} mag <= -2.0. Ran Partial OBO Mitigation checks.",
             )
         ]
+    return msgs
+
+
+def check_run_obo_checks(
+    acar: ACACheckTable, mitigation="partial", planet=None, planet_pos=None
+) -> list[Message]:
+    msgs = check_obo_spoilers(acar, planet, planet_pos)
+    msgs += check_run_obo_distribution_checks(
+        acar, mitigation=mitigation, planet=planet, planet_pos=planet_pos
+    )
     return msgs
 
 
@@ -205,8 +229,6 @@ def check_obo_acq_spoilers(
     list of Message
         List of messages from the bright object acquisition box check.
     """
-    from proseco.bright_object import get_bright_object_acq_pos
-
     msgs = []
     ok = np.isin(acar["type"], ("BOT", "ACQ"))
     acqs = acar[ok]
@@ -223,8 +245,9 @@ def check_obo_acq_spoilers(
         in_box = (jcol + pad >= col_min) & (jcol - pad <= col_max)
         if np.any(in_box):
             msg = (
-                f"{planet.capitalize()} column in acquisition box idx {entry['idx']} id {entry['id']}"
-                f" row {entry['row']:.1f} col {entry['col']:.1f}"
+                f"{planet.capitalize()} column in acquisition box idx "
+                f"{entry['idx']} id {entry['id']} "
+                f"row {entry['row']:.1f} col {entry['col']:.1f}"
             )
             msgs += [Message("critical", msg, idx=entry["idx"])]
     return msgs
@@ -253,8 +276,6 @@ def check_obo_track_spoilers(
     list of Message
         List of messages from the bright object tracked star check.
     """
-    from proseco.bright_object import check_spoiled_by_bright_object
-
     msgs = []
     ok = np.isin(acar["type"], ("GUI", "BOT", "FID"))
     guide_and_fid = acar[ok]
@@ -290,8 +311,6 @@ def check_partial_obo_distribution(
     list of Message
         List of messages from the bright object guide star distribution check.
     """
-    from proseco.bright_object import bright_object_distribution_check
-
     # Check that there are at least 2 guide stars in each quadrant of the ccd
     msgs = []
     ok = np.isin(acar["type"], ("GUI", "BOT"))
@@ -348,7 +367,7 @@ def check_full_obo_distribution(
         msgs += [
             Message(
                 "critical",
-                "Need 5 guide stars on each side of CCD opposite bright object.",
+                "Need 5 guide stars on side of CCD opposite bright object.",
             )
         ]
     if not two_fids_opposite:
@@ -356,7 +375,7 @@ def check_full_obo_distribution(
         msgs += [
             Message(
                 "critical",
-                "Need 2 fid lights on each side of CCD opposite bright object.",
+                "Need 2 fid lights on side of CCD opposite bright object.",
             )
         ]
     if not obo_not_near_boundary:

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -3,23 +3,22 @@ import functools
 from itertools import combinations
 
 import astropy.units as u
-from cxotime import CxoTime
-from chandra_aca.planets import BRIGHT_PLANETS
+import numpy as np
+import proseco.characteristics as ACA
 from chandra_aca.planets import (
+    BRIGHT_PLANETS,
     get_planet_chandra_ccd_position,
     get_planet_mag_states,
 )
-import numpy as np
-import proseco.characteristics as ACA
 from chandra_aca.transform import mag_to_count_rate, snr_mag_for_t_ccd
-from proseco.core import ACACatalogTableRow, StarsTableRow
+from cxotime import CxoTime
 from proseco.bright_object import (
-    get_bright_object_acq_pos,
+    bright_object_distribution_check,
     check_for_close_planets,
     check_spoiled_by_bright_object,
-    bright_object_distribution_check
+    get_bright_object_acq_pos,
 )
-
+from proseco.core import ACACatalogTableRow, StarsTableRow
 
 from sparkles.aca_check_table import ACACheckTable
 from sparkles.messages import Message

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -319,12 +319,25 @@ def check_partial_obo_distribution(
     # Check that there are at least 2 guide stars in each quadrant of the ccd
     msgs = []
     ok = np.isin(acar["type"], ("GUI", "BOT"))
-    if not bright_object_distribution_check(acar[ok], planet_pos):
+    distribution_ok, crosses_midline = bright_object_distribution_check(
+        acar[ok], planet_pos
+    )
+    if not distribution_ok:
         msg = (
             "Partial OBO guide star distribution check failed. "
             "Need 2 guide stars always opposite bright object."
         )
         msgs += [Message("critical", msg)]
+
+        if crosses_midline:
+            msgs += [
+                Message(
+                    "info",
+                    "Bright object extent crosses midline. "
+                    "2 guide stars on each side of CCD are required.",
+                )
+            ]
+
     return msgs
 
 

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -7,7 +7,6 @@ import numpy as np
 import proseco.characteristics as ACA
 from chandra_aca.planets import (
     BRIGHT_PLANETS,
-    get_planet_chandra_ccd_position,
     get_planet_mag_states,
 )
 from chandra_aca.transform import mag_to_count_rate, snr_mag_for_t_ccd
@@ -78,7 +77,14 @@ def check_guide_overlap(acar: ACACheckTable) -> list[Message]:
 def check_planets(acar: ACACheckTable) -> list[Message]:
     """Check for planets on the CCD and run appropriate checks."""
 
+    return get_planet_check_data(acar)["messages"]
+
+
+def get_planet_check_data(acar: ACACheckTable) -> dict:
+    """Get planet check messages and derived mitigation flags for a catalog."""
+
     msgs = []
+    planet_full_mitigation = False
     duration = acar.duration if acar.duration is not None else 0.0
     target_name = str(getattr(acar, "target_name", "") or "")
     target_name_lower = target_name.lower()
@@ -87,10 +93,7 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
     planets_on_ccd = {}
 
     for planet in planets:
-        # If the table is empty, just skip
-        if len(planets[planet]) == 0:
-            continue
-
+        planet_pos = planets[planet]
         mag_states = get_planet_mag_states(
             planet, acar.date, CxoTime(acar.date) + duration * u.s
         )
@@ -98,17 +101,9 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
         min_state_idx = np.argmin(mag_states["mag_start"])
         min_state = mag_states[min_state_idx]
 
-        planet_pos = get_planet_chandra_ccd_position(
-            planet,
-            acar.date,
-            duration,
-            acar.att,
-            ephem_source="stk",
-        )
-
         # If planet is within 2 degrees but not on CCD, that's a critical
         if len(planet_pos) == 0:
-            if not np.all(mag_states["label"] == "no action"):
+            if min_state["label"] != "no action":
                 msgs += [
                     Message(
                         "critical",
@@ -141,6 +136,15 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
                 )
             ]
 
+        # Always emit an info message summarizing the planet state.
+        msgs += [
+            Message(
+                "info",
+                f"{planet.capitalize()} on CCD. "
+                f"(mag {min_state['mag_start']:.1f} to {min_state['mag_stop']:.1f}).",
+            )
+        ]
+
         # Run direct spoiler checks for any planet on CCD, even if the
         # current magnitude does not require full or partial mitigation.
         msgs += check_obo_spoilers(acar, planet=planet, planet_pos=planet_pos)
@@ -148,10 +152,11 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
         # Distribution checks apply only in explicit mitigation states.
         if min_state["label"] in ["partial mitigation", "full mitigation"]:
             mitigation = "full" if min_state["label"].startswith("full") else "partial"
+            if mitigation == "full":
+                planet_full_mitigation = True
             msgs += check_run_obo_distribution_checks(
                 acar,
                 mitigation=mitigation,
-                planet=planet,
                 planet_pos=planet_pos,
             )
 
@@ -163,7 +168,10 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
                     f"{planet.capitalize()} in target name '{target_name}' but not on CCD.",
                 )
             ]
-    return msgs
+    return {
+        "messages": msgs,
+        "planet_full_mitigation": planet_full_mitigation,
+    }
 
 
 def check_obo_spoilers(
@@ -176,25 +184,13 @@ def check_obo_spoilers(
 
 
 def check_run_obo_distribution_checks(
-    acar: ACACheckTable, mitigation="partial", planet=None, planet_pos=None
+    acar: ACACheckTable, mitigation="partial", planet_pos=None
 ) -> list[Message]:
     msgs = []
     if mitigation == "full":
         msgs += check_full_obo_distribution(acar, planet_pos)
-        msgs += [
-            Message(
-                "info",
-                f"{planet.capitalize()} mag <= -2.9. Ran Full OBO Mitigation checks.",
-            )
-        ]
     else:
         msgs += check_partial_obo_distribution(acar, planet_pos)
-        msgs += [
-            Message(
-                "info",
-                f"{planet.capitalize()} mag <= -2.0. Ran Partial OBO Mitigation checks.",
-            )
-        ]
     return msgs
 
 
@@ -203,7 +199,7 @@ def check_run_obo_checks(
 ) -> list[Message]:
     msgs = check_obo_spoilers(acar, planet, planet_pos)
     msgs += check_run_obo_distribution_checks(
-        acar, mitigation=mitigation, planet=planet, planet_pos=planet_pos
+        acar, mitigation=mitigation, planet_pos=planet_pos
     )
     return msgs
 

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -123,7 +123,7 @@ def check_planets(acar: ACACheckTable) -> list[Message]:
             if min_state["label"] in [
                 "partial mitigation",
                 "full mitigation",
-                "instrument_notify",
+                "instrument notify",
             ]:
                 warning_level = "warning"
             elif min_state["label"] == "no action":
@@ -185,9 +185,9 @@ def check_obo_acq_spoilers(
     acar: ACACheckTable, planet=None, planet_pos=None
 ) -> list[Message]:
     """
-    Check for columns spoiled by Jupiter in acquisition boxes.
+    Check for columns spoiled by a bright object in acquisition boxes.
 
-    This uses a 15 column pad around Jupiter.
+    This uses a 15 column pad around the bright object.
 
     It does not explicitly use an estimate of maneuver error.
 
@@ -195,11 +195,15 @@ def check_obo_acq_spoilers(
     ----------
     acar : ACACheckTable
         The ACA review table to check.
+    planet : str, optional
+        Planet name (lowercase)
+    planet_pos : Table, optional
+        Bright object position table
 
     Returns
     -------
     list of Message
-        List of messages from the jupiter acquisition box check.
+        List of messages from the bright object acquisition box check.
     """
     from proseco.bright_object import get_bright_object_acq_pos
 
@@ -219,7 +223,7 @@ def check_obo_acq_spoilers(
         in_box = (jcol + pad >= col_min) & (jcol - pad <= col_max)
         if np.any(in_box):
             msg = (
-                f"{planet} column in acquisition box idx {entry['idx']} id {entry['id']}"
+                f"{planet.capitalize()} column in acquisition box idx {entry['idx']} id {entry['id']}"
                 f" row {entry['row']:.1f} col {entry['col']:.1f}"
             )
             msgs += [Message("critical", msg, idx=entry["idx"])]
@@ -230,20 +234,24 @@ def check_obo_track_spoilers(
     acar: ACACheckTable, planet=None, planet_pos=None
 ) -> list[Message]:
     """
-    Check for Jupiter spoiling stars or fids.
+    Check for bright object spoiling stars or fids.
 
-    This uses proseco.jupiter.check_spoiled_by_jupiter to determine
-    if any tracked stars or fids are spoiled by Jupiter.
+    This uses proseco.bright_object.check_spoiled_by_bright_object to determine
+    if any tracked stars or fids are spoiled by the bright object.
 
     Parameters
     ----------
     acar : ACACheckTable
         The ACA review table to check.
+    planet : str, optional
+        Planet name (lowercase)
+    planet_pos : Table, optional
+        Bright object position table
 
     Returns
     -------
     list of Message
-        List of messages from the jupiter tracked star check.
+        List of messages from the bright object tracked star check.
     """
     from proseco.bright_object import check_spoiled_by_bright_object
 
@@ -261,7 +269,7 @@ def check_partial_obo_distribution(
     acar: ACACheckTable, planet_pos=None
 ) -> list[Message]:
     """
-    Check for guide star distribution for Jupiter fields.
+    Check for guide star distribution for bright object fields.
 
     The guideline requires at least 2 guide stars on the CCD half opposite
     the bright object, one side of the CCD is positive in row and the other negative.
@@ -274,11 +282,13 @@ def check_partial_obo_distribution(
     ----------
     acar : ACACheckTable
         The ACA review table to check.
+    planet_pos : Table, optional
+        Bright object position table
 
     Returns
     -------
     list of Message
-        List of messages from the jupiter guide star distribution check.
+        List of messages from the bright object guide star distribution check.
     """
     from proseco.bright_object import bright_object_distribution_check
 

--- a/sparkles/checks.py
+++ b/sparkles/checks.py
@@ -91,12 +91,25 @@ def get_planet_check_data(acar: ACACheckTable) -> dict:
     planets = check_for_close_planets(acar.date, duration, acar.att)
 
     planets_on_ccd = {}
+    planets_skipped_empty_mag_states = set()
 
     for planet in planets:
         planet_pos = planets[planet]
         mag_states = get_planet_mag_states(
             planet, acar.date, CxoTime(acar.date) + duration * u.s
         )
+        if len(mag_states) == 0:
+            planets_skipped_empty_mag_states.add(planet)
+            if len(planet_pos) > 0:
+                msgs += [
+                    Message(
+                        "caution",
+                        f"{planet.capitalize()} on CCD but no mag states available. "
+                        "Skipping planet checks.",
+                    )
+                ]
+            continue
+
         # min/brightest mag state
         min_state_idx = np.argmin(mag_states["mag_start"])
         min_state = mag_states[min_state_idx]
@@ -127,12 +140,12 @@ def get_planet_check_data(acar: ACACheckTable) -> dict:
                 "instrument notify",
             ]:
                 warning_level = "warning"
-            elif min_state["label"] == "no action":
+            else:
                 warning_level = "info"
             msgs += [
                 Message(
                     warning_level,
-                    f"Bright object alert: {planet.title()} on CCD but not in target name\n",
+                    f"Bright object alert: {planet.title()} on CCD but not in target name",
                 )
             ]
 
@@ -161,6 +174,8 @@ def get_planet_check_data(acar: ACACheckTable) -> dict:
             )
 
     for planet in BRIGHT_PLANETS:
+        if planet in planets_skipped_empty_mag_states:
+            continue
         if planet.lower() in target_name_lower and planet not in planets_on_ccd:
             msgs += [
                 Message(

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1031,16 +1031,20 @@ check_guide_fid_position_on_ccd = checks.acar_check_wrapper(
     checks.check_guide_fid_position_on_ccd
 )
 check_guide_geometry = checks.acar_check_wrapper(checks.check_guide_geometry)
-check_run_jupiter_checks = checks.acar_check_wrapper(checks.check_run_jupiter_checks)
-check_jupiter_acq_spoilers = checks.acar_check_wrapper(
-    checks.check_jupiter_acq_spoilers
+check_run_obo_checks = checks.acar_check_wrapper(checks.check_run_obo_checks)
+check_obo_acq_spoilers = checks.acar_check_wrapper(
+    checks.check_obo_acq_spoilers
 )
-check_jupiter_track_spoilers = checks.acar_check_wrapper(
-    checks.check_jupiter_track_spoilers
+check_obo_track_spoilers = checks.acar_check_wrapper(
+    checks.check_obo_track_spoilers
 )
-check_jupiter_distribution = checks.acar_check_wrapper(
-    checks.check_jupiter_distribution
+check_partial_obo_distribution = checks.acar_check_wrapper(
+    checks.check_partial_obo_distribution
 )
+# Backward compatibility aliases
+check_jupiter_acq_spoilers = check_obo_acq_spoilers
+check_jupiter_track_spoilers = check_obo_track_spoilers
+check_jupiter_distribution = check_partial_obo_distribution
 check_guide_is_candidate = checks.acar_check_wrapper(checks.check_guide_is_candidate)
 check_guide_overlap = checks.acar_check_wrapper(checks.check_guide_overlap)
 check_imposters_guide = checks.acar_check_wrapper(checks.check_imposters_guide)
@@ -1075,8 +1079,10 @@ def check_catalog(acar: ACACheckTable) -> None:
             fid = acar.fids.get_id(entry["id"])
             msgs += checks.check_fid_spoiler_score(entry["idx"], fid)
 
+
     msgs += checks.check_guide_overlap(acar)
-    msgs += checks.check_run_jupiter_checks(acar)
+
+    msgs += checks.check_planets(acar)
     msgs += checks.check_guide_geometry(acar)
     msgs += checks.check_acq_p2(acar)
     msgs += checks.check_guide_count(acar)

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1032,12 +1032,8 @@ check_guide_fid_position_on_ccd = checks.acar_check_wrapper(
 )
 check_guide_geometry = checks.acar_check_wrapper(checks.check_guide_geometry)
 check_run_obo_checks = checks.acar_check_wrapper(checks.check_run_obo_checks)
-check_obo_acq_spoilers = checks.acar_check_wrapper(
-    checks.check_obo_acq_spoilers
-)
-check_obo_track_spoilers = checks.acar_check_wrapper(
-    checks.check_obo_track_spoilers
-)
+check_obo_acq_spoilers = checks.acar_check_wrapper(checks.check_obo_acq_spoilers)
+check_obo_track_spoilers = checks.acar_check_wrapper(checks.check_obo_track_spoilers)
 check_partial_obo_distribution = checks.acar_check_wrapper(
     checks.check_partial_obo_distribution
 )
@@ -1078,7 +1074,6 @@ def check_catalog(acar: ACACheckTable) -> None:
         if is_fid:
             fid = acar.fids.get_id(entry["id"])
             msgs += checks.check_fid_spoiler_score(entry["idx"], fid)
-
 
     msgs += checks.check_guide_overlap(acar)
 

--- a/sparkles/core.py
+++ b/sparkles/core.py
@@ -1037,10 +1037,6 @@ check_obo_track_spoilers = checks.acar_check_wrapper(checks.check_obo_track_spoi
 check_partial_obo_distribution = checks.acar_check_wrapper(
     checks.check_partial_obo_distribution
 )
-# Backward compatibility aliases
-check_jupiter_acq_spoilers = check_obo_acq_spoilers
-check_jupiter_track_spoilers = check_obo_track_spoilers
-check_jupiter_distribution = check_partial_obo_distribution
 check_guide_is_candidate = checks.acar_check_wrapper(checks.check_guide_is_candidate)
 check_guide_overlap = checks.acar_check_wrapper(checks.check_guide_overlap)
 check_imposters_guide = checks.acar_check_wrapper(checks.check_imposters_guide)

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -76,7 +76,26 @@ def test_venus_bad():
         kwargs_raw["att"],
     )
     check_run_obo_checks(acar, mitigation="full", planet="venus", planet_pos=pos)
-    assert acar.messages == [{'category': 'critical', 'text': 'Need 5 guide stars on each side of CCD opposite bright object.'}, {'category': 'critical', 'text': 'Need 2 fid lights on each side of CCD opposite bright object.'}, {'category': 'critical', 'text': 'Bright object tracks too close to CCD boundary row=0.'}, {'category': 'critical', 'text': 'Need at least 6 guide stars in the catalog.'}, {'category': 'critical', 'text': 'Full mitigation OBO checks failed.'}, {'category': 'info', 'text': 'Venus mag <= -2.9. Ran Full OBO Mitigation checks.'}]
+    assert acar.messages == [
+        {
+            "category": "critical",
+            "text": "Need 5 guide stars on each side of CCD opposite bright object.",
+        },
+        {
+            "category": "critical",
+            "text": "Need 2 fid lights on each side of CCD opposite bright object.",
+        },
+        {
+            "category": "critical",
+            "text": "Bright object tracks too close to CCD boundary row=0.",
+        },
+        {"category": "critical", "text": "Need at least 6 guide stars in the catalog."},
+        {"category": "critical", "text": "Full mitigation OBO checks failed."},
+        {
+            "category": "info",
+            "text": "Venus mag <= -2.9. Ran Full OBO Mitigation checks.",
+        },
+    ]
 
 
 def test_venus_good():
@@ -107,7 +126,12 @@ def test_venus_good():
     aca2 = get_aca_catalog(**kwargs_mod)
     acar2 = aca2.get_review_table()
     check_run_obo_checks(acar2, mitigation="full", planet="venus", planet_pos=pos2)
-    assert acar2.messages == [{'category': 'info', 'text': 'Venus mag <= -2.9. Ran Full OBO Mitigation checks.'}]
+    assert acar2.messages == [
+        {
+            "category": "info",
+            "text": "Venus mag <= -2.9. Ran Full OBO Mitigation checks.",
+        }
+    ]
 
 
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 import tables
 from astropy.table import Table
+from chandra_aca.planets import get_planet_chandra_ccd_position
 from chandra_aca.transform import mag_to_count_rate
 from cxotime import CxoTime
 from packaging.version import Version
@@ -27,11 +28,12 @@ from sparkles.core import (
     check_guide_geometry,
     check_imposters_guide,
     check_include_exclude,
-    check_jupiter_acq_spoilers,
-    check_jupiter_distribution,
-    check_jupiter_track_spoilers,
+    check_obo_acq_spoilers,
+    check_partial_obo_distribution,
+    check_obo_track_spoilers,
     check_pos_err_guide,
     check_too_bright_guide,
+    check_run_obo_checks,
 )
 
 
@@ -47,6 +49,61 @@ def test_check_slice_index():
         for name in acar1.colnames:
             assert np.all(acar1[name] == acar[name][item])
 
+def test_venus_bad():
+    kwargs_raw = {'obsid': 18696.1,
+            'att': [-0.54152552, 0.17005146, -0.10308105, 0.81682734],
+            'man_angle': 90,
+            'date': '2017:010:06:57:57.000',
+            't_ccd': -10,
+            'dither': (7.9992, 7.9992),
+            'detector': 'ACIS-I',
+            'sim_offset': 0,
+            'focus_offset': 0,
+            'n_acq': 8,
+            'n_guide': 5,
+            'n_fid': 3,
+            'target_name': 'Venus'}
+    aca = get_aca_catalog(**kwargs_raw)
+    acar = aca.get_review_table()
+    #acar.run_aca_review(make_html=False)
+    pos = get_planet_chandra_ccd_position(
+            "venus",
+            kwargs_raw["date"],
+            6000,
+            kwargs_raw["att"],
+    )
+    check_run_obo_checks(acar, mitigation="full", planet="venus", planet_pos=pos)
+    assert acar.messages == [{'category': 'critical', 'text': 'Need 5 guide stars on each side of CCD opposite bright object.'}, {'category': 'critical', 'text': 'Need 2 fid lights on each side of CCD opposite bright object.'}, {'category': 'critical', 'text': 'Bright object tracks too close to CCD boundary row=0.'}, {'category': 'critical', 'text': 'Need at least 6 guide stars in the catalog.'}, {'category': 'critical', 'text': 'Full mitigation OBO checks failed.'}, {'category': 'info', 'text': 'Bright object mag <= -2.9. Ran Full OBO Mitigation checks.'}]
+
+
+def test_venus_good():
+    # This has an attitude munged so that venus doesn't get close to midline
+    # And also specifies guide and fid lights to satisfy full mitigation requirements
+    kwargs_mod = {'obsid': 18696.2,
+            'att': [-0.54159041,  0.16984442, -0.10339331,  0.81678793],
+            'man_angle': 90,
+            'date': '2017:010:06:57:57.000',
+            't_ccd': -10,
+            'dither': (7.9992, 7.9992),
+            'detector': 'ACIS-I',
+            'sim_offset': 0,
+            'focus_offset': 0,
+            'n_acq': 8,
+            'n_guide': 6,
+            'n_fid': 2,
+            'target_name': 'Venus',
+            'include_ids_fid': [2, 5]}
+    pos2 = get_planet_chandra_ccd_position(
+            "venus",
+            kwargs_mod["date"],
+            6000,
+            kwargs_mod["att"],
+    )
+    aca2 = get_aca_catalog(**kwargs_mod)
+    acar2 = aca2.get_review_table()
+    check_run_obo_checks(acar2, mitigation="full", planet="venus", planet_pos=pos2)
+    assert acar2.messages == [{'category': 'info', 'text': 'Bright object mag <= -2.9. Ran Full OBO Mitigation checks.'}]
+
 
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))
 def test_check_jupiter_acq_spoilers_fail(aca_review_table):
@@ -56,7 +113,7 @@ def test_check_jupiter_acq_spoilers_fail(aca_review_table):
         **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
     )
     acar = aca_review_table(aca)
-    acar.jupiter = Table(
+    acar.planets = {'jupiter': Table(
         [
             {
                 "time": CxoTime(acar.date).secs,
@@ -64,17 +121,17 @@ def test_check_jupiter_acq_spoilers_fail(aca_review_table):
                 "col": stars[0]["col"],
             }
         ]
-    )
-    check_jupiter_acq_spoilers(acar)
+    )}
+    check_obo_acq_spoilers(acar, planet="jupiter", planet_pos=acar.planets['jupiter'])
     assert acar.messages == [
         {
             "category": "critical",
-            "text": "Jupiter column in acquisition box idx 4 id 100 row -295.2 col 5.5",
+            "text": "Jupiter column in acquisition box idx 4 id 100 row -295.0 col 5.4",
             "idx": 4,
         },
         {
             "category": "critical",
-            "text": "Jupiter column in acquisition box idx 6 id 102 row 307.2 col 4.3",
+            "text": "Jupiter column in acquisition box idx 6 id 102 row 307.1 col 4.4",
             "idx": 6,
         },
     ]
@@ -88,8 +145,8 @@ def test_check_jupiter_acq_spoilers_none(aca_review_table):
         **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
     )
     acar = aca_review_table(aca)
-    acar.jupiter = Table([{"time": CxoTime(acar.date).secs, "row": 0, "col": 100}])
-    check_jupiter_acq_spoilers(acar)
+    acar.planets = {'jupiter': Table([{"time": CxoTime(acar.date).secs, "row": 0, "col": 100}])}
+    check_obo_acq_spoilers(acar, planet="jupiter", planet_pos=acar.planets['jupiter'])
     assert acar.messages == []
 
 
@@ -103,22 +160,22 @@ def test_check_jupiter_track_spoilers_true(aca_review_table, jupiter_col_offset)
         **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
     )
     acar = aca_review_table(aca)
-    acar.jupiter = Table(
+    acar.planets = {'jupiter': Table(
         [{"time": CxoTime(acar.date).secs, "row": 0, "col": jupiter_col_offset + 5}]
-    )
-    check_jupiter_track_spoilers(acar)
+    )}
+    check_obo_track_spoilers(acar, planet="jupiter", planet_pos=acar.planets['jupiter'])
     exp_messages = (
         []
         if abs(jupiter_col_offset) > 15
         else [
             {
                 "category": "critical",
-                "text": "Jupiter spoils tracked star idx 4 id 100",
+                "text": "jupiter spoils tracked star idx 4 id 100",
                 "idx": 4,
             },
             {
                 "category": "critical",
-                "text": "Jupiter spoils tracked star idx 6 id 102",
+                "text": "jupiter spoils tracked star idx 6 id 102",
                 "idx": 6,
             },
         ]
@@ -138,18 +195,18 @@ def test_check_jupiter_distribution(aca_review_table, jupiter_row):
         **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
     )
     acar = aca_review_table(aca)
-    acar.jupiter = Table(
+    acar.planets = {'jupiter': Table(
         [{"time": CxoTime(acar.date).secs, "row": jupiter_row, "col": 10}]
-    )
-    check_jupiter_distribution(acar)
+    )}
+    check_partial_obo_distribution(acar, planet_pos=acar.planets['jupiter'])
     exp = (
         []
         if jupiter_row < 0
         else [
             {
                 "category": "critical",
-                "text": "Jupiter guide star distribution check failed. "
-                "Need 2 guide stars always opposite Jupiter.",
+                "text": "Partial OBO guide star distribution check failed. "
+                "Need 2 guide stars always opposite bright object.",
             }
         ]
     )
@@ -164,19 +221,19 @@ def test_check_jupiter_distribution_cross(aca_review_table):
     aca = get_aca_catalog(**STD_INFO, duration=20000, stars=stars, dark=DARK40)
     acar = aca_review_table(aca)
     # And have Jupiter cross the center
-    acar.jupiter = Table(
+    acar.planets = {'jupiter': Table(
         [
             {"time": CxoTime(acar.date).secs, "row": -0.1, "col": -10},
             {"time": CxoTime(acar.date).secs + 1000, "row": 0.1, "col": 10},
         ]
-    )
+    )}
     # There is no way to satisfy the distribution requirement with 3 stars
     # and Jupiter crossing.
-    check_jupiter_distribution(acar)
+    check_partial_obo_distribution(acar, planet_pos=acar.planets['jupiter'])
     assert acar.messages == [
         {
             "category": "critical",
-            "text": "Jupiter guide star distribution check failed. Need 2 guide stars always opposite Jupiter.",
+            "text": "Partial OBO guide star distribution check failed. Need 2 guide stars always opposite bright object.",
         }
     ]
 

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -29,11 +29,11 @@ from sparkles.core import (
     check_imposters_guide,
     check_include_exclude,
     check_obo_acq_spoilers,
-    check_partial_obo_distribution,
     check_obo_track_spoilers,
+    check_partial_obo_distribution,
     check_pos_err_guide,
-    check_too_bright_guide,
     check_run_obo_checks,
+    check_too_bright_guide,
 )
 
 
@@ -49,60 +49,89 @@ def test_check_slice_index():
         for name in acar1.colnames:
             assert np.all(acar1[name] == acar[name][item])
 
+
 def test_venus_bad():
-    kwargs_raw = {'obsid': 18696.1,
-            'att': [-0.54152552, 0.17005146, -0.10308105, 0.81682734],
-            'man_angle': 90,
-            'date': '2017:010:06:57:57.000',
-            't_ccd': -10,
-            'dither': (7.9992, 7.9992),
-            'detector': 'ACIS-I',
-            'sim_offset': 0,
-            'focus_offset': 0,
-            'n_acq': 8,
-            'n_guide': 5,
-            'n_fid': 3,
-            'target_name': 'Venus'}
+    kwargs_raw = {
+        "obsid": 18696.1,
+        "att": [-0.54152552, 0.17005146, -0.10308105, 0.81682734],
+        "man_angle": 90,
+        "date": "2017:010:06:57:57.000",
+        "t_ccd": -10,
+        "dither": (7.9992, 7.9992),
+        "detector": "ACIS-I",
+        "sim_offset": 0,
+        "focus_offset": 0,
+        "n_acq": 8,
+        "n_guide": 5,
+        "n_fid": 3,
+        "target_name": "Venus",
+    }
     aca = get_aca_catalog(**kwargs_raw)
     acar = aca.get_review_table()
-    #acar.run_aca_review(make_html=False)
+    # acar.run_aca_review(make_html=False)
     pos = get_planet_chandra_ccd_position(
-            "venus",
-            kwargs_raw["date"],
-            6000,
-            kwargs_raw["att"],
+        "venus",
+        kwargs_raw["date"],
+        6000,
+        kwargs_raw["att"],
     )
     check_run_obo_checks(acar, mitigation="full", planet="venus", planet_pos=pos)
-    assert acar.messages == [{'category': 'critical', 'text': 'Need 5 guide stars on each side of CCD opposite bright object.'}, {'category': 'critical', 'text': 'Need 2 fid lights on each side of CCD opposite bright object.'}, {'category': 'critical', 'text': 'Bright object tracks too close to CCD boundary row=0.'}, {'category': 'critical', 'text': 'Need at least 6 guide stars in the catalog.'}, {'category': 'critical', 'text': 'Full mitigation OBO checks failed.'}, {'category': 'info', 'text': 'Bright object mag <= -2.9. Ran Full OBO Mitigation checks.'}]
+    assert acar.messages == [
+        {
+            "category": "critical",
+            "text": "Need 5 guide stars on each side of CCD opposite bright object.",
+        },
+        {
+            "category": "critical",
+            "text": "Need 2 fid lights on each side of CCD opposite bright object.",
+        },
+        {
+            "category": "critical",
+            "text": "Bright object tracks too close to CCD boundary row=0.",
+        },
+        {"category": "critical", "text": "Need at least 6 guide stars in the catalog."},
+        {"category": "critical", "text": "Full mitigation OBO checks failed."},
+        {
+            "category": "info",
+            "text": "Bright object mag <= -2.9. Ran Full OBO Mitigation checks.",
+        },
+    ]
 
 
 def test_venus_good():
     # This has an attitude munged so that venus doesn't get close to midline
     # And also specifies guide and fid lights to satisfy full mitigation requirements
-    kwargs_mod = {'obsid': 18696.2,
-            'att': [-0.54159041,  0.16984442, -0.10339331,  0.81678793],
-            'man_angle': 90,
-            'date': '2017:010:06:57:57.000',
-            't_ccd': -10,
-            'dither': (7.9992, 7.9992),
-            'detector': 'ACIS-I',
-            'sim_offset': 0,
-            'focus_offset': 0,
-            'n_acq': 8,
-            'n_guide': 6,
-            'n_fid': 2,
-            'target_name': 'Venus',
-            'include_ids_fid': [2, 5]}
+    kwargs_mod = {
+        "obsid": 18696.2,
+        "att": [-0.54159041, 0.16984442, -0.10339331, 0.81678793],
+        "man_angle": 90,
+        "date": "2017:010:06:57:57.000",
+        "t_ccd": -10,
+        "dither": (7.9992, 7.9992),
+        "detector": "ACIS-I",
+        "sim_offset": 0,
+        "focus_offset": 0,
+        "n_acq": 8,
+        "n_guide": 6,
+        "n_fid": 2,
+        "target_name": "Venus",
+        "include_ids_fid": [2, 5],
+    }
     pos2 = get_planet_chandra_ccd_position(
-            "venus",
-            kwargs_mod["date"],
-            6000,
-            kwargs_mod["att"],
+        "venus",
+        kwargs_mod["date"],
+        6000,
+        kwargs_mod["att"],
     )
     aca2 = get_aca_catalog(**kwargs_mod)
     acar2 = aca2.get_review_table()
     check_run_obo_checks(acar2, mitigation="full", planet="venus", planet_pos=pos2)
-    assert acar2.messages == [{'category': 'info', 'text': 'Bright object mag <= -2.9. Ran Full OBO Mitigation checks.'}]
+    assert acar2.messages == [
+        {
+            "category": "info",
+            "text": "Bright object mag <= -2.9. Ran Full OBO Mitigation checks.",
+        }
+    ]
 
 
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))
@@ -113,16 +142,18 @@ def test_check_jupiter_acq_spoilers_fail(aca_review_table):
         **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
     )
     acar = aca_review_table(aca)
-    acar.planets = {'jupiter': Table(
-        [
-            {
-                "time": CxoTime(acar.date).secs,
-                "row": stars[0]["row"],
-                "col": stars[0]["col"],
-            }
-        ]
-    )}
-    check_obo_acq_spoilers(acar, planet="jupiter", planet_pos=acar.planets['jupiter'])
+    acar.planets = {
+        "jupiter": Table(
+            [
+                {
+                    "time": CxoTime(acar.date).secs,
+                    "row": stars[0]["row"],
+                    "col": stars[0]["col"],
+                }
+            ]
+        )
+    }
+    check_obo_acq_spoilers(acar, planet="jupiter", planet_pos=acar.planets["jupiter"])
     assert acar.messages == [
         {
             "category": "critical",
@@ -145,8 +176,10 @@ def test_check_jupiter_acq_spoilers_none(aca_review_table):
         **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
     )
     acar = aca_review_table(aca)
-    acar.planets = {'jupiter': Table([{"time": CxoTime(acar.date).secs, "row": 0, "col": 100}])}
-    check_obo_acq_spoilers(acar, planet="jupiter", planet_pos=acar.planets['jupiter'])
+    acar.planets = {
+        "jupiter": Table([{"time": CxoTime(acar.date).secs, "row": 0, "col": 100}])
+    }
+    check_obo_acq_spoilers(acar, planet="jupiter", planet_pos=acar.planets["jupiter"])
     assert acar.messages == []
 
 
@@ -160,10 +193,12 @@ def test_check_jupiter_track_spoilers_true(aca_review_table, jupiter_col_offset)
         **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
     )
     acar = aca_review_table(aca)
-    acar.planets = {'jupiter': Table(
-        [{"time": CxoTime(acar.date).secs, "row": 0, "col": jupiter_col_offset + 5}]
-    )}
-    check_obo_track_spoilers(acar, planet="jupiter", planet_pos=acar.planets['jupiter'])
+    acar.planets = {
+        "jupiter": Table(
+            [{"time": CxoTime(acar.date).secs, "row": 0, "col": jupiter_col_offset + 5}]
+        )
+    }
+    check_obo_track_spoilers(acar, planet="jupiter", planet_pos=acar.planets["jupiter"])
     exp_messages = (
         []
         if abs(jupiter_col_offset) > 15
@@ -195,10 +230,12 @@ def test_check_jupiter_distribution(aca_review_table, jupiter_row):
         **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
     )
     acar = aca_review_table(aca)
-    acar.planets = {'jupiter': Table(
-        [{"time": CxoTime(acar.date).secs, "row": jupiter_row, "col": 10}]
-    )}
-    check_partial_obo_distribution(acar, planet_pos=acar.planets['jupiter'])
+    acar.planets = {
+        "jupiter": Table(
+            [{"time": CxoTime(acar.date).secs, "row": jupiter_row, "col": 10}]
+        )
+    }
+    check_partial_obo_distribution(acar, planet_pos=acar.planets["jupiter"])
     exp = (
         []
         if jupiter_row < 0
@@ -221,15 +258,17 @@ def test_check_jupiter_distribution_cross(aca_review_table):
     aca = get_aca_catalog(**STD_INFO, duration=20000, stars=stars, dark=DARK40)
     acar = aca_review_table(aca)
     # And have Jupiter cross the center
-    acar.planets = {'jupiter': Table(
-        [
-            {"time": CxoTime(acar.date).secs, "row": -0.1, "col": -10},
-            {"time": CxoTime(acar.date).secs + 1000, "row": 0.1, "col": 10},
-        ]
-    )}
+    acar.planets = {
+        "jupiter": Table(
+            [
+                {"time": CxoTime(acar.date).secs, "row": -0.1, "col": -10},
+                {"time": CxoTime(acar.date).secs + 1000, "row": 0.1, "col": 10},
+            ]
+        )
+    }
     # There is no way to satisfy the distribution requirement with 3 stars
     # and Jupiter crossing.
-    check_partial_obo_distribution(acar, planet_pos=acar.planets['jupiter'])
+    check_partial_obo_distribution(acar, planet_pos=acar.planets["jupiter"])
     assert acar.messages == [
         {
             "category": "critical",

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -144,7 +144,13 @@ def test_check_planets_instrument_notify_runs_spoiler_checks(monkeypatch):
     acar = aca.get_review_table()
 
     planet_pos = Table(
-        [{"time": CxoTime(acar.date).secs, "row": stars[0]["row"], "col": stars[0]["col"]}]
+        [
+            {
+                "time": CxoTime(acar.date).secs,
+                "row": stars[0]["row"],
+                "col": stars[0]["col"],
+            }
+        ]
     )
 
     def fake_check_for_close_planets(date, duration, att):
@@ -168,11 +174,10 @@ def test_check_planets_instrument_notify_runs_spoiler_checks(monkeypatch):
     monkeypatch.setattr(
         sparkle_checks, "check_for_close_planets", fake_check_for_close_planets
     )
+    monkeypatch.setattr(sparkle_checks, "get_planet_mag_states", fake_get_planet_mag_states)
     monkeypatch.setattr(
-        "chandra_aca.planets.get_planet_mag_states", fake_get_planet_mag_states
-    )
-    monkeypatch.setattr(
-        "chandra_aca.planets.get_planet_chandra_ccd_position",
+        sparkle_checks,
+        "get_planet_chandra_ccd_position",
         fake_get_planet_chandra_ccd_position,
     )
 
@@ -180,9 +185,24 @@ def test_check_planets_instrument_notify_runs_spoiler_checks(monkeypatch):
     msg_texts = [msg.text for msg in msgs]
 
     assert any("Mars column in acquisition box" in text for text in msg_texts)
-    assert any("mars spoils tracked star" in text for text in msg_texts)
+    assert any("Mars spoils tracked star" in text for text in msg_texts)
     assert not any("Ran Partial OBO Mitigation checks." in text for text in msg_texts)
     assert not any("Ran Full OBO Mitigation checks." in text for text in msg_texts)
+
+
+def test_check_planets_handles_none_target_name(monkeypatch):
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(n_stars=4, mag=8.5)
+    aca = get_aca_catalog(
+        **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
+    )
+    acar = aca.get_review_table()
+    acar.target_name = None
+
+    monkeypatch.setattr(sparkle_checks, "check_for_close_planets", lambda *args: {})
+
+    msgs = sparkle_checks.check_planets(acar)
+    assert msgs == []
 
 
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))
@@ -256,12 +276,12 @@ def test_check_jupiter_track_spoilers_true(aca_review_table, jupiter_col_offset)
         else [
             {
                 "category": "critical",
-                "text": "jupiter spoils tracked star idx 4 id 100",
+                "text": "Jupiter spoils tracked star idx 4 id 100",
                 "idx": 4,
             },
             {
                 "category": "critical",
-                "text": "jupiter spoils tracked star idx 6 id 102",
+                "text": "Jupiter spoils tracked star idx 6 id 102",
                 "idx": 6,
             },
         ]

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -92,10 +92,6 @@ def test_venus_bad():
         },
         {"category": "critical", "text": "Need at least 6 guide stars in the catalog."},
         {"category": "critical", "text": "Full mitigation OBO checks failed."},
-        {
-            "category": "info",
-            "text": "Venus mag <= -2.9. Ran Full OBO Mitigation checks.",
-        },
     ]
 
 
@@ -127,12 +123,7 @@ def test_venus_good():
     aca2 = get_aca_catalog(**kwargs_mod)
     acar2 = aca2.get_review_table()
     check_run_obo_checks(acar2, mitigation="full", planet="venus", planet_pos=pos2)
-    assert acar2.messages == [
-        {
-            "category": "info",
-            "text": "Venus mag <= -2.9. Ran Full OBO Mitigation checks.",
-        }
-    ]
+    assert acar2.messages == []
 
 
 def test_check_planets_instrument_notify_runs_spoiler_checks(monkeypatch):
@@ -165,27 +156,17 @@ def test_check_planets_instrument_notify_runs_spoiler_checks(monkeypatch):
             }
         )
 
-    def fake_get_planet_chandra_ccd_position(
-        planet, date, duration, att, ephem_source="cxc"
-    ):
-        assert ephem_source == "stk"
-        return planet_pos
-
     monkeypatch.setattr(
         sparkle_checks, "check_for_close_planets", fake_check_for_close_planets
     )
     monkeypatch.setattr(
         sparkle_checks, "get_planet_mag_states", fake_get_planet_mag_states
     )
-    monkeypatch.setattr(
-        sparkle_checks,
-        "get_planet_chandra_ccd_position",
-        fake_get_planet_chandra_ccd_position,
-    )
 
     msgs = sparkle_checks.check_planets(acar)
     msg_texts = [msg.text for msg in msgs]
 
+    assert any("Mars on CCD. (mag -1.9 to -1.0)." in text for text in msg_texts)
     assert any("Mars column in acquisition box" in text for text in msg_texts)
     assert any("Mars spoils tracked star" in text for text in msg_texts)
     assert not any("Ran Partial OBO Mitigation checks." in text for text in msg_texts)
@@ -205,6 +186,41 @@ def test_check_planets_handles_none_target_name(monkeypatch):
 
     msgs = sparkle_checks.check_planets(acar)
     assert msgs == []
+
+
+def test_check_planets_warns_when_bright_planet_is_off_ccd(monkeypatch):
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(n_stars=4, mag=8.5)
+    aca = get_aca_catalog(
+        **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
+    )
+    acar = aca.get_review_table()
+
+    off_ccd_planet = Table({"time": [], "row": [], "col": []})
+
+    monkeypatch.setattr(
+        sparkle_checks,
+        "check_for_close_planets",
+        lambda *args: {"mars": off_ccd_planet},
+    )
+    monkeypatch.setattr(
+        sparkle_checks,
+        "get_planet_mag_states",
+        lambda *args, **kwargs: Table(
+            {
+                "label": ["partial mitigation"],
+                "mag_start": [-2.5],
+                "mag_stop": [-2.0],
+            }
+        ),
+    )
+
+    msgs = sparkle_checks.check_planets(acar)
+
+    assert any(
+        msg.category == "critical" and msg.text == "Mars within 2 deg but not on CCD."
+        for msg in msgs
+    )
 
 
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -18,6 +18,7 @@ from proseco.tests.test_common import DARK40, STD_INFO, mod_std_info
 from Quaternion import Quat
 
 from sparkles import ACAReviewTable, get_t_ccds_bonus
+from sparkles import checks as sparkle_checks
 from sparkles.aca_check_table import ACACheckTable
 from sparkles.core import (
     check_acq_p2,
@@ -79,11 +80,11 @@ def test_venus_bad():
     assert acar.messages == [
         {
             "category": "critical",
-            "text": "Need 5 guide stars on each side of CCD opposite bright object.",
+            "text": "Need 5 guide stars on side of CCD opposite bright object.",
         },
         {
             "category": "critical",
-            "text": "Need 2 fid lights on each side of CCD opposite bright object.",
+            "text": "Need 2 fid lights on side of CCD opposite bright object.",
         },
         {
             "category": "critical",
@@ -132,6 +133,56 @@ def test_venus_good():
             "text": "Venus mag <= -2.9. Ran Full OBO Mitigation checks.",
         }
     ]
+
+
+def test_check_planets_instrument_notify_runs_spoiler_checks(monkeypatch):
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(n_stars=4, mag=8.5)
+    aca = get_aca_catalog(
+        **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
+    )
+    acar = aca.get_review_table()
+
+    planet_pos = Table(
+        [{"time": CxoTime(acar.date).secs, "row": stars[0]["row"], "col": stars[0]["col"]}]
+    )
+
+    def fake_check_for_close_planets(date, duration, att):
+        return {"mars": planet_pos}
+
+    def fake_get_planet_mag_states(planet, start, stop):
+        return Table(
+            {
+                "label": ["instrument notify"],
+                "mag_start": [-1.9],
+                "mag_stop": [-1.0],
+            }
+        )
+
+    def fake_get_planet_chandra_ccd_position(
+        planet, date, duration, att, ephem_source="cxc"
+    ):
+        assert ephem_source == "stk"
+        return planet_pos
+
+    monkeypatch.setattr(
+        sparkle_checks, "check_for_close_planets", fake_check_for_close_planets
+    )
+    monkeypatch.setattr(
+        "chandra_aca.planets.get_planet_mag_states", fake_get_planet_mag_states
+    )
+    monkeypatch.setattr(
+        "chandra_aca.planets.get_planet_chandra_ccd_position",
+        fake_get_planet_chandra_ccd_position,
+    )
+
+    msgs = sparkle_checks.check_planets(acar)
+    msg_texts = [msg.text for msg in msgs]
+
+    assert any("Mars column in acquisition box" in text for text in msg_texts)
+    assert any("mars spoils tracked star" in text for text in msg_texts)
+    assert not any("Ran Partial OBO Mitigation checks." in text for text in msg_texts)
+    assert not any("Ran Full OBO Mitigation checks." in text for text in msg_texts)
 
 
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -76,26 +76,7 @@ def test_venus_bad():
         kwargs_raw["att"],
     )
     check_run_obo_checks(acar, mitigation="full", planet="venus", planet_pos=pos)
-    assert acar.messages == [
-        {
-            "category": "critical",
-            "text": "Need 5 guide stars on each side of CCD opposite bright object.",
-        },
-        {
-            "category": "critical",
-            "text": "Need 2 fid lights on each side of CCD opposite bright object.",
-        },
-        {
-            "category": "critical",
-            "text": "Bright object tracks too close to CCD boundary row=0.",
-        },
-        {"category": "critical", "text": "Need at least 6 guide stars in the catalog."},
-        {"category": "critical", "text": "Full mitigation OBO checks failed."},
-        {
-            "category": "info",
-            "text": "Bright object mag <= -2.9. Ran Full OBO Mitigation checks.",
-        },
-    ]
+    assert acar.messages == [{'category': 'critical', 'text': 'Need 5 guide stars on each side of CCD opposite bright object.'}, {'category': 'critical', 'text': 'Need 2 fid lights on each side of CCD opposite bright object.'}, {'category': 'critical', 'text': 'Bright object tracks too close to CCD boundary row=0.'}, {'category': 'critical', 'text': 'Need at least 6 guide stars in the catalog.'}, {'category': 'critical', 'text': 'Full mitigation OBO checks failed.'}, {'category': 'info', 'text': 'Venus mag <= -2.9. Ran Full OBO Mitigation checks.'}]
 
 
 def test_venus_good():
@@ -126,12 +107,7 @@ def test_venus_good():
     aca2 = get_aca_catalog(**kwargs_mod)
     acar2 = aca2.get_review_table()
     check_run_obo_checks(acar2, mitigation="full", planet="venus", planet_pos=pos2)
-    assert acar2.messages == [
-        {
-            "category": "info",
-            "text": "Bright object mag <= -2.9. Ran Full OBO Mitigation checks.",
-        }
-    ]
+    assert acar2.messages == [{'category': 'info', 'text': 'Venus mag <= -2.9. Ran Full OBO Mitigation checks.'}]
 
 
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -230,13 +230,13 @@ def test_check_jupiter_acq_spoilers_fail(aca_review_table):
     assert acar.messages == [
         {
             "category": "critical",
-            "text": "Jupiter column in acquisition box idx 4 id 100 row -295.0 col 5.4",
-            "idx": 4,
+            "text": "Jupiter column in acquisition box idx 4 id 100 row -295.2 col 5.5",
+            "idx": np.int64(4),
         },
         {
             "category": "critical",
-            "text": "Jupiter column in acquisition box idx 6 id 102 row 307.1 col 4.4",
-            "idx": 6,
+            "text": "Jupiter column in acquisition box idx 6 id 102 row 307.2 col 4.3",
+            "idx": np.int64(6),
         },
     ]
 

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -173,6 +173,52 @@ def test_check_planets_instrument_notify_runs_spoiler_checks(monkeypatch):
     assert not any("Ran Full OBO Mitigation checks." in text for text in msg_texts)
 
 
+def test_check_planets_obo_too_bright(monkeypatch):
+    """
+    Do a monkeypatch test on the obo-too-bright path.
+
+    This is justified because none of the current bright planets are actually
+    too bright over the interval out to 2041.
+    """
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(n_stars=4, mag=8.5)
+    aca = get_aca_catalog(
+        **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
+    )
+    acar = aca.get_review_table()
+
+    planet_pos = Table(
+        [
+            {
+                "time": CxoTime(acar.date).secs,
+                "row": stars[0]["row"],
+                "col": stars[0]["col"],
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        sparkle_checks,
+        "check_for_close_planets",
+        lambda *args: {"venus": planet_pos},
+    )
+    monkeypatch.setattr(
+        sparkle_checks,
+        "get_planet_mag_states",
+        lambda *args, **kwargs: Table(
+            {
+                "label": ["obo too bright"],
+                "mag_start": [-30.0],
+                "mag_stop": [-5.0],
+            }
+        ),
+    )
+
+    msgs = sparkle_checks.check_planets(acar)
+
+    assert msgs == [sparkle_checks.Message("critical", "Venus too bright.")]
+
+
 def test_check_planets_handles_none_target_name(monkeypatch):
     stars = StarsTable.empty()
     stars.add_fake_constellation(n_stars=4, mag=8.5)

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -174,7 +174,9 @@ def test_check_planets_instrument_notify_runs_spoiler_checks(monkeypatch):
     monkeypatch.setattr(
         sparkle_checks, "check_for_close_planets", fake_check_for_close_planets
     )
-    monkeypatch.setattr(sparkle_checks, "get_planet_mag_states", fake_get_planet_mag_states)
+    monkeypatch.setattr(
+        sparkle_checks, "get_planet_mag_states", fake_get_planet_mag_states
+    )
     monkeypatch.setattr(
         sparkle_checks,
         "get_planet_chandra_ccd_position",
@@ -344,7 +346,11 @@ def test_check_jupiter_distribution_cross(aca_review_table):
         {
             "category": "critical",
             "text": "Partial OBO guide star distribution check failed. Need 2 guide stars always opposite bright object.",
-        }
+        },
+        {
+            "category": "info",
+            "text": "Bright object extent crosses midline. 2 guide stars on each side of CCD are required.",
+        },
     ]
 
 

--- a/sparkles/tests/test_checks.py
+++ b/sparkles/tests/test_checks.py
@@ -223,6 +223,45 @@ def test_check_planets_warns_when_bright_planet_is_off_ccd(monkeypatch):
     )
 
 
+def test_check_planets_skips_empty_mag_states(monkeypatch):
+    stars = StarsTable.empty()
+    stars.add_fake_constellation(n_stars=4, mag=8.5)
+    aca = get_aca_catalog(
+        **mod_std_info(detector="HRC-I"), duration=20000, stars=stars, dark=DARK40
+    )
+    acar = aca.get_review_table()
+    acar.target_name = "Mars"
+
+    mars_pos = Table(
+        [
+            {
+                "time": CxoTime(acar.date).secs,
+                "row": stars[0]["row"],
+                "col": stars[0]["col"],
+            }
+        ]
+    )
+
+    monkeypatch.setattr(
+        sparkle_checks,
+        "check_for_close_planets",
+        lambda *args: {"mars": mars_pos},
+    )
+    monkeypatch.setattr(
+        sparkle_checks,
+        "get_planet_mag_states",
+        lambda *args, **kwargs: Table({"label": [], "mag_start": [], "mag_stop": []}),
+    )
+
+    msgs = sparkle_checks.check_planets(acar)
+    assert msgs == [
+        sparkle_checks.Message(
+            "caution",
+            "Mars on CCD but no mag states available. Skipping planet checks.",
+        )
+    ]
+
+
 @pytest.mark.parametrize("aca_review_table", (ACAReviewTable, ACACheckTable))
 def test_check_jupiter_acq_spoilers_fail(aca_review_table):
     stars = StarsTable.empty()

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -62,7 +62,7 @@ def test_jupiter_present():
     acar.run_aca_review(make_html=False)
     assert acar.messages[-1] == {
         "category": "info",
-        "text": "Jupiter mag <= -2.0. Ran Partial OBO Mitigation checks.",
+        "text": "Jupiter on CCD. (mag -2.9 to -2.0).",
     }
 
 
@@ -197,7 +197,7 @@ def test_review_mars():
     assert acar.messages == [
         {
             "category": "info",
-            "text": "Mars mag <= -2.0. Ran Partial OBO Mitigation checks.",
+            "text": "Mars on CCD. (mag -2.9 to -2.0).",
         }
     ]
 
@@ -227,14 +227,14 @@ def test_review_venus():
     acar.run_aca_review()
     assert acar.messages == [
         {
+            "category": "info",
+            "text": "Venus on CCD. (mag -5.0 to -2.9).",
+        },
+        {
             "category": "critical",
             "text": "Bright object tracks too close to CCD boundary row=0.",
         },
         {"category": "critical", "text": "Full mitigation OBO checks failed."},
-        {
-            "category": "info",
-            "text": "Venus mag <= -2.9. Ran Full OBO Mitigation checks.",
-        },
         {"category": "caution", "text": "OR with 6 guides requested but 5 is typical"},
         {"category": "caution", "text": "OR requested 2 fids but 3 is typical"},
         {"category": "info", "text": "included fid ID(s): [4, 6]"},
@@ -271,10 +271,7 @@ def test_review_venus_fixed():
     acar = aca.get_review_table()
     acar.run_aca_review()
     assert acar.messages == [
-        {
-            "category": "info",
-            "text": "Venus mag <= -2.9. Ran Full OBO Mitigation checks.",
-        },
+        {"category": "info", "text": "Venus on CCD. (mag -5.0 to -2.9)."},
         {"category": "caution", "text": "OR with 6 guides requested but 5 is typical"},
         {"category": "caution", "text": "OR requested 2 fids but 3 is typical"},
         {
@@ -313,6 +310,10 @@ def test_review_saturn():
         {
             "category": "info",
             "text": "Bright object alert: Saturn on CCD but not in target name\n",
+        },
+        {
+            "category": "info",
+            "text": "Saturn on CCD. (mag 0.0 to 40.0).",
         },
     ]
 

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -309,7 +309,7 @@ def test_review_saturn():
         },
         {
             "category": "info",
-            "text": "Bright object alert: Saturn on CCD but not in target name\n",
+            "text": "Bright object alert: Saturn on CCD but not in target name",
         },
         {
             "category": "info",

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -175,6 +175,101 @@ def test_review_catalog(proseco_agasc_1p7, tmpdir):
     assert (obspath / "rolls" / "index.html").exists()
 
 
+def test_review_mars():
+    kwargs = {
+        "obsid": 22688,
+        "att": [-0.48255572, -0.10809006, 0.10760397, 0.86248357],
+        "man_angle": 90,
+        "date": "2020:299:15:45:57.000",
+        "t_ccd": -10,
+        "dither": (20.0016, 20.0016),
+        "detector": "HRC-I",
+        "sim_offset": 0,
+        "focus_offset": 0,
+        "n_acq": 8,
+        "n_guide": 5,
+        "n_fid": 3,
+        "target_name": "Mars",
+    }
+    aca = get_aca_catalog(**kwargs)
+    acar = aca.get_review_table()
+    acar.run_aca_review()
+    assert acar.messages == [
+        {
+            "category": "info",
+            "text": "Mars mag <= -2.0. Ran Partial OBO Mitigation checks.",
+        }
+    ]
+
+
+def test_review_venus():
+    kwargs = {
+        "obsid": 16500,
+        "att": [-0.39679561, 0.60054118, -0.33972900, 0.60538230],
+        "man_angle": 90,
+        "date": "2013:312:09:00:13.000",
+        "t_ccd": -10,
+        "dither": (7.9992, 7.9992),
+        "detector": "ACIS-I",
+        "sim_offset": 0,
+        "focus_offset": 0,
+        "n_acq": 8,
+        "n_guide": 6,
+        "n_fid": 2,
+        "include_ids_fid": [4, 6],
+        "target_name": "Venus",
+    }
+    aca = get_aca_catalog(**kwargs)
+    acar = aca.get_review_table()
+    acar.run_aca_review()
+    assert acar.messages == [
+        {
+            "category": "critical",
+            "text": "Bright object tracks too close to CCD boundary row=0.",
+        },
+        {"category": "critical", "text": "Full mitigation OBO checks failed."},
+        {
+            "category": "info",
+            "text": "Venus mag <= -2.9. Ran Full OBO Mitigation checks.",
+        },
+        {"category": "caution", "text": "OR with 6 guides requested but 5 is typical"},
+        {"category": "caution", "text": "OR requested 2 fids but 3 is typical"},
+        {"category": "info", "text": "included fid ID(s): [4, 6]"},
+    ]
+
+
+def test_review_saturn():
+    kwargs = {
+        "obsid": 24847,
+        "att": [-0.46938362, 0.43566643, -0.28160247, 0.71454449],
+        "man_angle": 90,
+        "date": "2020:328:22:44:10.000",
+        "t_ccd": -10,
+        "dither": (20.0016, 20.0016),
+        "detector": "HRC-I",
+        "sim_offset": 0,
+        "focus_offset": 0,
+        "n_acq": 8,
+        "n_guide": 5,
+        "n_fid": 3,
+        "target_name": "Mystery",
+    }
+    aca = get_aca_catalog(**kwargs)
+    acar = aca.get_review_table()
+    acar.run_aca_review()
+    assert acar.messages == [
+        {
+            "category": "warning",
+            "text": "Fid 3 has yellow spoiler: star 829031248 with mag 11.50",
+            "idx": 2,
+        },
+        {
+            "category": "info",
+            "text": "Bright object alert: Saturn on CCD but not in target name\n",
+        },
+    ]
+
+
 def test_review_roll_options():
     """
     Test that the 'acar' key in the roll_option dict is an ACAReviewTable

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -81,7 +81,7 @@ def test_jupiter_not_present():
         msg
         == {
             "category": "warning",
-            "text": "Jupiter not on CCD, expected for target 'NO JUPITER HERE'",
+            "text": "Jupiter in target name 'NO JUPITER HERE' but not on CCD.",
         }
         for msg in acar.messages
     )

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -34,6 +34,8 @@ KWARGS_48464 = {
 }
 
 
+
+
 def test_jupiter_present():
     """Test that Jupiter checks run nominally for an observation in 2025 with Jupiter
     present and in target name"""

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -34,8 +34,6 @@ KWARGS_48464 = {
 }
 
 
-
-
 def test_jupiter_present():
     """Test that Jupiter checks run nominally for an observation in 2025 with Jupiter
     present and in target name"""

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -220,7 +220,10 @@ def test_review_venus():
         "target_name": "Venus",
     }
     aca = get_aca_catalog(**kwargs)
-    acar = aca.get_review_table()
+
+    # Run this one from the pkl to confirm the mitigation data is working
+    aca2 = pickle.loads(pickle.dumps(aca))
+    acar = aca2.get_review_table()
     acar.run_aca_review()
     assert acar.messages == [
         {

--- a/sparkles/tests/test_review.py
+++ b/sparkles/tests/test_review.py
@@ -238,6 +238,50 @@ def test_review_venus():
     ]
 
 
+def test_review_venus_fixed():
+    kwargs = {
+        "obsid": -200,
+        "att": [-0.49877014, -0.29681368, 0.20445036, 0.78824491],
+        "duration": 5000,
+        "man_angle": 90,
+        "date": "2026:100:00:00:10.000",
+        "t_ccd": -10,
+        "dither": (16, 16),
+        "detector": "ACIS-I",
+        "sim_offset": 0,
+        "focus_offset": 0,
+        "n_acq": 8,
+        "n_guide": 6,
+        "include_ids_guide": [
+            84545472,
+            159396848,
+            159397320,
+            84541632,
+            160313992,
+            84543464,
+        ],
+        "n_fid": 2,
+        "include_ids_fid": [4, 6],
+        "target_name": "Venus",
+    }
+    aca = get_aca_catalog(**kwargs)
+    acar = aca.get_review_table()
+    acar.run_aca_review()
+    assert acar.messages == [
+        {
+            "category": "info",
+            "text": "Venus mag <= -2.9. Ran Full OBO Mitigation checks.",
+        },
+        {"category": "caution", "text": "OR with 6 guides requested but 5 is typical"},
+        {"category": "caution", "text": "OR requested 2 fids but 3 is typical"},
+        {
+            "category": "info",
+            "text": "included guide ID(s): [84545472, 159396848, 159397320, 84541632, 160313992, 84543464]",
+        },
+        {"category": "info", "text": "included fid ID(s): [4, 6]"},
+    ]
+
+
 def test_review_saturn():
     kwargs = {
         "obsid": 24847,


### PR DESCRIPTION
## Description

This PR removes Jupiter-specific checking and generalizes the code to handle the optically bright planets.  Much of the new code to work generically with the optically bright planets data and planet functions upstream in chandra_aca and proseco.

This PR requires 

https://github.com/sot/chandra_aca/pull/203
and
https://github.com/sot/proseco/pull/415

---

Functional behavior with this PR is:

- Sparkles gets candidate bright planets over the observation interval.
- For each candidate planet, Sparkles gets its brightest magnitude state over the interval from chandra_aca.
- The chandra_aca magnitude states used here are:
  - no action (0.0 <= m < 40)
  - instrument notify (-2.0 <= m < 0.0) 
  - partial mitigation (-2.9 <= m < -2.0)
  - full mitigation (-5.0 <= m < -2.9)
  - obo too bright (-30.0 <= m < -5.0)

Per-planet Sparkles behavior:

- If the planet is within 2 degrees of the pointing but is not on the CCD:
  - Sparkles treats it as off-CCD for checking.
  - If magnitude state is anything but "no action", Sparkles emits a critical message and stops checks for that planet.
- If the planet is on CCD:
  - If magnitude state is obo too bright, Sparkles emits a critical message and stops checks for that planet.
  - If the planet is not in the target name:
    - info if magnitude level is no action
    - otherwise warning 
  - Sparkles emits an info summary for the on-CCD planet, including the magnitude range for the selected state.
  - Sparkles  runs acquisition and tracking spoiler checks for bright planets on the CCD.
  - Sparkles runs distribution checks (to get stars and fids opposite bright planets) only for partial mitigation and full mitigation.
- If the planet is on CCD but no magnitude-state table could be read, Sparkles emits a caution and skips checks for that planet.

---



## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
This PR requires 

https://github.com/sot/chandra_aca/pull/203
and
https://github.com/sot/proseco/pull/415

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-latest) flame:sparkles jean$ env PYTHONPATH=/Users/jean/git/obo/chandra_aca:/Users/jean/git/obo/proseco pytest
============================================================ test session starts ============================================================
platform darwin -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 139 items                                                                                                                         

sparkles/tests/test_checks.py ....................................................................................................... [ 74%]
..                                                                                                                                    [ 75%]
sparkles/tests/test_find_er_catalog.py .....                                                                                          [ 79%]
sparkles/tests/test_review.py .........................                                                                               [ 97%]
sparkles/tests/test_yoshi.py ....                                                                                                     [100%]

=========================================================== 139 passed in 45.31s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
